### PR TITLE
feat: add logging

### DIFF
--- a/internal/webhook/server.go
+++ b/internal/webhook/server.go
@@ -26,6 +26,7 @@ type Handler struct {
 }
 
 func (h *Handler) Webhook(w http.ResponseWriter, r *http.Request) {
+	requestReceiveTime := time.Now()
 	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
 	defer r.Body.Close()
 
@@ -33,31 +34,31 @@ func (h *Handler) Webhook(w http.ResponseWriter, r *http.Request) {
 	signature := r.Header.Get(WebhookSignatureHeader)
 	if signature == "" {
 		slog.DebugContext(ctx, "missing signature header", "header", r.Header)
-		respondWithError(w, r, http.StatusForbidden, "Missing signature header")
+		respondWithError(w, r, requestReceiveTime, http.StatusForbidden, "Missing signature header")
 		return
 	}
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		slog.Error("unable to read request body", "error", err)
-		respondWithError(w, r, http.StatusInternalServerError, "unable to read request body")
+		respondWithError(w, r, requestReceiveTime, http.StatusInternalServerError, "unable to read request body")
 		return
 	}
 
 	if !validateSignature(body, h.WebhookSecret, signature) {
 		slog.Debug("invalid signature", "signature", signature)
-		respondWithError(w, r, http.StatusForbidden, "Invalid signature")
+		respondWithError(w, r, requestReceiveTime, http.StatusForbidden, "Invalid signature")
 		return
 	}
 
 	err = h.Producer.Push(r.Context(), nil, body)
 	if err != nil {
 		slog.Error("unable to push message to queue", "error", err)
-		respondWithError(w, r, http.StatusInternalServerError, "Unable to push to queue")
+		respondWithError(w, r, requestReceiveTime, http.StatusInternalServerError, "Unable to push to queue")
 		return
 	}
 
-	logRequest(r, http.StatusOK, 0)
+	logRequest(r, requestReceiveTime, http.StatusOK, 0)
 }
 
 func validateSignature(message []byte, secret string, signature string) bool {
@@ -70,16 +71,16 @@ func validateSignature(message []byte, secret string, signature string) bool {
 	return hmac.Equal(h.Sum(nil), sig)
 }
 
-func respondWithError(w http.ResponseWriter, r *http.Request, status int, msg string) {
+func respondWithError(w http.ResponseWriter, r *http.Request, receiveTime time.Time, status int, msg string) {
 	http.Error(w, msg, status)
-	logRequest(r, status, len(msg))
+	logRequest(r, receiveTime, status, len(msg))
 }
 
-func logRequest(r *http.Request, status int, size int) {
+func logRequest(r *http.Request, receiveTime time.Time, status int, size int) {
 	slog.Info(fmt.Sprintf(
 		"%s - - [%s] \"%s %s %s\" %d %d \"%s\"",
 		r.RemoteAddr,
-		time.Now().Format("02/Jan/2006:15:04:05 -0700"),
+		receiveTime.Format("02/Jan/2006:15:04:05 -0700"),
 		r.Method,
 		r.URL.Path,
 		r.Proto,


### PR DESCRIPTION
### Overview

Add basic access logs

e.g. 

```
2025/10/06 13:12:50 INFO 127.0.0.1:38634 - - [06/Oct/2025:13:12:50 +0200] "POST /webhook HTTP/1.1" 200 0 "curl/7.81.0"
```

### Rationale

To help the operator understanding the deployment

### Checklist

- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`).

<!-- Explanation for any unchecked items above -->