### PR TITLE
add bot pr approval

### DIFF
--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -1,0 +1,9 @@
+name: Provide approval for bot PRs
+
+on:
+  pull_request:
+
+jobs:
+  bot_pr_approval:
+    uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main
+    secrets: inherit


### PR DESCRIPTION
### Overview

add bot pr approval

### Rationale

to auto-approve renovate PR's.

### Checklist

- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`).

<!-- Explanation for any unchecked items above -->