### PR TITLE
Fix the conversion of the tracing environment in the charm.

### DIFF
--- a/webhook-gateway/charm/src/charm.py
+++ b/webhook-gateway/charm/src/charm.py
@@ -36,7 +36,7 @@ class GithubRunnerWebhookGatewayCharm(paas_charm.go.Charm):
             env["OTEL_LOGS_EXPORTER"] = "console"
             if env.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
                 traces_endpoint = env["OTEL_EXPORTER_OTLP_ENDPOINT"]
-                env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = traces_endpoint.removesuffix("/") + "/v1/trace"
+                env["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = traces_endpoint.removesuffix("/") + "/v1/traces"
                 del env["OTEL_EXPORTER_OTLP_ENDPOINT"]
                 env["OTEL_TRACES_EXPORTER"] = "otlp"
                 env["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/protobuf"


### PR DESCRIPTION
### Overview

According to the [OpenTelemetry documentation](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_endpoint), for OTLP/HTTP, when converting the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, you need to add `/v1/traces` at the end. For example: `http://my-api-endpoint/` -> `http://my-api-endpoint/v1/traces`.

Fix this issue in the charm code.

### Rationale

<!-- The reason the change is needed -->

### Checklist

- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`).

<!-- Explanation for any unchecked items above -->