### PR TITLE
chore: set permission package write

### DIFF
--- a/.github/workflows/webhook_gateway_tests.yaml
+++ b/.github/workflows/webhook_gateway_tests.yaml
@@ -88,7 +88,6 @@ jobs:
       rockcraft-channel: latest/edge
       charmcraft-channel: latest/edge
       test-tox-env: webhook-gateway-integration
-      upload-image: ${{ startsWith(github.head_ref,  'copilot/') && 'artifact' || '' }}
 
 
   integration-status-check:


### PR DESCRIPTION
### Overview

Set package permission to write for the github token from GitHub Actions.
Remove "copilot upload-image" workaround

### Rationale

Suddenly, the permissions are no longer there .
### Checklist

- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`).

<!-- Explanation for any unchecked items above -->