### PR TITLE
fix(dashboard): remove dead override hiding job queue time series

### DIFF
--- a/.github/workflows/charms_lint_and_unit.yaml
+++ b/.github/workflows/charms_lint_and_unit.yaml
@@ -44,7 +44,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install tox
         run: uv tool install tox --with tox-uv

--- a/charms/planner-operator/cos_custom/grafana_dashboards/go.json
+++ b/charms/planner-operator/cos_custom/grafana_dashboards/go.json
@@ -590,32 +590,7 @@
           },
           "unit": "s"
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "histogram_quantile(0.95, \nsum by (le) (\n  rate(github_runner_planner_webhook_job_waiting_seconds_bucket[5m])\n  )\n)"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,


### PR DESCRIPTION
### Overview

Removes a leftover `hideSeriesFrom` override on the "Job queue time" panel of the planner Grafana dashboard (`charms/planner-operator/cos_custom/grafana_dashboards/go.json`).

### Rationale

The override excluded every series except one specific named expression. Because the panel's current PromQL already aggregates with `sum by (le)` and produces a single series, the exclusion rule matched nothing and the chart rendered empty. Dropping the override restores the visualisation; the query, unit, and panel layout are otherwise unchanged.

### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — N/A, dashboard JSON only
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — N/A, no docs changes