### PR TITLE
feat(planner): resolve sub-30s queue time and surface median

### DIFF
--- a/charms/planner-operator/cos_custom/grafana_dashboards/go.json
+++ b/charms/planner-operator/cos_custom/grafana_dashboards/go.json
@@ -536,7 +536,7 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "Time jobs waited between creation and starting, shown at the median (p50) and 95th percentile (p95)",
+      "description": "Median time jobs waited between creation and starting on a runner",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -594,7 +594,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 6,
         "x": 12,
         "y": 16
       },
@@ -622,10 +622,97 @@
           "editorMode": "code",
           "expr": "histogram_quantile(0.50, \nsum by (le) (\n  rate(github_runner_planner_webhook_job_waiting_seconds_bucket[5m])\n  )\n)",
           "instant": false,
-          "legendFormat": "p50",
+          "legendFormat": "Median (p50)",
           "range": true,
           "refId": "A"
+        }
+      ],
+      "title": "Job queue time (median)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusds}"
+      },
+      "description": "95th percentile time jobs waited between creation and starting on a runner (tail latency)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 16
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2",
+      "targets": [
         {
           "datasource": {
             "type": "prometheus",
@@ -634,12 +721,12 @@
           "editorMode": "code",
           "expr": "histogram_quantile(0.95, \nsum by (le) (\n  rate(github_runner_planner_webhook_job_waiting_seconds_bucket[5m])\n  )\n)",
           "instant": false,
-          "legendFormat": "p95",
+          "legendFormat": "95th percentile (p95)",
           "range": true,
-          "refId": "B"
+          "refId": "A"
         }
       ],
-      "title": "Job queue time",
+      "title": "Job queue time (p95)",
       "type": "timeseries"
     },
     {

--- a/charms/planner-operator/cos_custom/grafana_dashboards/go.json
+++ b/charms/planner-operator/cos_custom/grafana_dashboards/go.json
@@ -536,7 +536,7 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "Median time jobs waited between creation and starting on a runner",
+      "description": "Median time jobs waited between creation and starting on a runner. Note: for workflows with `needs:` or `concurrency:`, this includes dependency/blocking wait time, not just runner-queue wait — the value can therefore overstate pickup time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -635,7 +635,7 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "95th percentile time jobs waited between creation and starting on a runner (tail latency)",
+      "description": "95th percentile time jobs waited between creation and starting on a runner (tail latency). Note: for workflows with `needs:` or `concurrency:`, this includes dependency/blocking wait time, not just runner-queue wait — the value can therefore overstate pickup time.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/charms/planner-operator/cos_custom/grafana_dashboards/go.json
+++ b/charms/planner-operator/cos_custom/grafana_dashboards/go.json
@@ -536,7 +536,7 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "Median time jobs waited between creation and starting on a runner. Treat with caution: this measures `started_at − created_at`, but for workflows with `needs:` or `concurrency:` the job's effective queued time (when it became eligible for a runner) may be later than `created_at`, so the value can overstate runner pickup time.",
+      "description": "Median time jobs waited between creation and starting on a runner. Treat with caution: this measures `started_at − created_at`, but the job's effective queued time (when it became eligible for a runner) may be later than `created_at`, so the value can overstate runner pickup time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -604,7 +604,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "tooltip": {
           "hideZeros": false,
@@ -635,7 +635,7 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "95th percentile time jobs waited between creation and starting on a runner (tail latency). Treat with caution: this measures `started_at − created_at`, but for workflows with `needs:` or `concurrency:` the job's effective queued time (when it became eligible for a runner) may be later than `created_at`, so the value can overstate runner pickup time.",
+      "description": "95th percentile time jobs waited between creation and starting on a runner (tail latency). Treat with caution: this measures `started_at − created_at`, but the job's effective queued time (when it became eligible for a runner) may be later than `created_at`, so the value can overstate runner pickup time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -703,7 +703,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
         "tooltip": {
           "hideZeros": false,

--- a/charms/planner-operator/cos_custom/grafana_dashboards/go.json
+++ b/charms/planner-operator/cos_custom/grafana_dashboards/go.json
@@ -536,7 +536,7 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "Median time jobs waited between creation and starting on a runner. Note: for workflows with `needs:` or `concurrency:`, this includes dependency/blocking wait time, not just runner-queue wait — the value can therefore overstate pickup time.",
+      "description": "Median time jobs waited between creation and starting on a runner. Treat with caution: this measures `started_at − created_at`, but for workflows with `needs:` or `concurrency:` the job's effective queued time (when it became eligible for a runner) may be later than `created_at`, so the value can overstate runner pickup time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -635,7 +635,7 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "95th percentile time jobs waited between creation and starting on a runner (tail latency). Note: for workflows with `needs:` or `concurrency:`, this includes dependency/blocking wait time, not just runner-queue wait — the value can therefore overstate pickup time.",
+      "description": "95th percentile time jobs waited between creation and starting on a runner (tail latency). Treat with caution: this measures `started_at − created_at`, but for workflows with `needs:` or `concurrency:` the job's effective queued time (when it became eligible for a runner) may be later than `created_at`, so the value can overstate runner pickup time.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/charms/planner-operator/cos_custom/grafana_dashboards/go.json
+++ b/charms/planner-operator/cos_custom/grafana_dashboards/go.json
@@ -536,7 +536,7 @@
         "type": "prometheus",
         "uid": "${prometheusds}"
       },
-      "description": "95% of jobs waited less than this amount of time before starting",
+      "description": "Time jobs waited between creation and starting, shown at the median (p50) and 95th percentile (p95)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -604,7 +604,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
@@ -620,11 +620,23 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, \nsum by (le) (\n  rate(github_runner_planner_webhook_job_waiting_seconds_bucket[5m])\n  )\n)",
+          "expr": "histogram_quantile(0.50, \nsum by (le) (\n  rate(github_runner_planner_webhook_job_waiting_seconds_bucket[5m])\n  )\n)",
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "p50",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusds}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, \nsum by (le) (\n  rate(github_runner_planner_webhook_job_waiting_seconds_bucket[5m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Job queue time",

--- a/internal/planner/telemetry.go
+++ b/internal/planner/telemetry.go
@@ -139,7 +139,7 @@ func NewMetrics(store FlavorStore) *Metrics {
 	m.webhookJobWaitingTime = must(
 		m.meter.Float64Histogram(
 			webhookJobWaitingTimeMetricName,
-			metric.WithDescription("Histogram of job waiting times from webhook reception to job start"),
+			metric.WithDescription("Histogram of time between workflow_job creation and job start on a runner"),
 			metric.WithUnit("s"),
 			jobWaitingBucket,
 		),

--- a/internal/planner/telemetry.go
+++ b/internal/planner/telemetry.go
@@ -116,7 +116,26 @@ func NewMetrics(store FlavorStore) *Metrics {
 		300*60,
 		360*60,
 	)
-	jobWaitingBucket := jobDurationBucket
+	// Queue times are usually lower than job running times, so the bucket
+	// layout resolves the low end more finely and caps the tail earlier.
+	jobWaitingBucket := metric.WithExplicitBucketBoundaries(
+		0,
+		1,
+		2.5,
+		5,
+		10,
+		15,
+		30,
+		60,
+		2*60,
+		5*60,
+		10*60,
+		20*60,
+		30*60,
+		60*60,
+		2*60*60,
+		4*60*60,
+	)
 	m.webhookJobWaitingTime = must(
 		m.meter.Float64Histogram(
 			webhookJobWaitingTimeMetricName,

--- a/internal/planner/telemetry_test.go
+++ b/internal/planner/telemetry_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/canonical/github-runner-operators/internal/database"
 	"github.com/canonical/github-runner-operators/internal/telemetry"
+	"github.com/google/go-github/v82/github"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -314,6 +315,62 @@ func TestMust(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWaitingTimeHistogramResolvesBelowThirtySeconds(t *testing.T) {
+	/*
+		arrange: metrics instance and an in_progress webhook with a 5-second wait
+		act: observe the webhook and collect metrics
+		assert: the waiting-time histogram exposes at least one bucket boundary
+			strictly below 30 seconds, so sub-30s queue times are not collapsed
+			into a single bucket and low percentiles (p50/p80) remain meaningful
+	*/
+	r := telemetry.AcquireTestMetricReader(t)
+	defer telemetry.ReleaseTestMetricReader(t)
+
+	m := NewMetrics(&mockStore{})
+
+	createdAt := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	startedAt := createdAt.Add(5 * time.Second)
+	event := &github.WorkflowJobEvent{
+		Action: github.String("in_progress"),
+		WorkflowJob: &github.WorkflowJob{
+			CreatedAt: &github.Timestamp{Time: createdAt},
+			StartedAt: &github.Timestamp{Time: startedAt},
+		},
+		Repo: &github.Repository{FullName: github.String("acme/demo")},
+	}
+	m.ObserveConsumedGitHubWebhook(context.Background(), event)
+
+	tm := r.Collect(t)
+
+	var bounds []float64
+	for _, sm := range tm.ScopeMetrics {
+		for _, md := range sm.Metrics {
+			if md.Name != webhookJobWaitingTimeMetricName {
+				continue
+			}
+			hist, ok := md.Data.(metricdata.Histogram[float64])
+			if !ok {
+				t.Fatalf("expected histogram data for %s", md.Name)
+			}
+			if len(hist.DataPoints) == 0 {
+				t.Fatalf("expected at least one data point for %s", md.Name)
+			}
+			bounds = hist.DataPoints[0].Bounds
+		}
+	}
+	assert.NotEmpty(t, bounds, "waiting-time histogram must be recorded")
+
+	hasSubThirty := false
+	for _, b := range bounds {
+		if b > 0 && b < 30 {
+			hasSubThirty = true
+			break
+		}
+	}
+	assert.True(t, hasSubThirty,
+		"waiting-time histogram should have bucket boundaries below 30s for p50/p80 resolution, got bounds=%v", bounds)
 }
 
 func TestNewMetricsInitialization(t *testing.T) {

--- a/internal/planner/telemetry_test.go
+++ b/internal/planner/telemetry_test.go
@@ -323,7 +323,7 @@ func TestWaitingTimeHistogramResolvesBelowThirtySeconds(t *testing.T) {
 		act: observe the webhook and collect metrics
 		assert: the waiting-time histogram exposes at least one bucket boundary
 			strictly below 30 seconds, so sub-30s queue times are not collapsed
-			into a single bucket and low percentiles (p50/p80) remain meaningful
+			into a single bucket and low percentiles remain meaningful
 	*/
 	r := telemetry.AcquireTestMetricReader(t)
 	defer telemetry.ReleaseTestMetricReader(t)
@@ -370,7 +370,7 @@ func TestWaitingTimeHistogramResolvesBelowThirtySeconds(t *testing.T) {
 		}
 	}
 	assert.True(t, hasSubThirty,
-		"waiting-time histogram should have bucket boundaries below 30s for p50/p80 resolution, got bounds=%v", bounds)
+		"waiting-time histogram should have bucket boundaries below 30s for low-percentile resolution, got bounds=%v", bounds)
 }
 
 func TestNewMetricsInitialization(t *testing.T) {


### PR DESCRIPTION
### Overview

Two related improvements to the planner's "Job queue time" panel and the metric behind it:

1. **Bucket layout** (`internal/planner/telemetry.go`) — the waiting-time histogram no longer reuses the running-time bucket boundaries. Queue times are usually lower than job running times, so the new layout resolves the low end more finely (`1, 2.5, 5, 10, 15, 30s`) and caps the tail earlier (at 4h). Sub-30s queue times now land in distinct buckets instead of collapsing into a single one.

2. **Dashboard** (`charms/planner-operator/cos_custom/grafana_dashboards/go.json`) — the single "Job queue time" panel is split into two side-by-side panels: "Job queue time (median)" and "Job queue time (p95)". They live in the same dashboard slot the original panel occupied. The split is needed because the two series differ by orders of magnitude (median in seconds–minutes, p95 sometimes in hours), so a shared Y axis squashed the median to a flat line near zero. With separate panels each axis auto-scales independently. The panel descriptions also flag a caveat: `started_at − created_at` may overstate runner pickup time because the job's effective queued time can be later than `created_at`.

<img width="1633" height="928" alt="image" src="https://github.com/user-attachments/assets/19ba4dd5-0309-49ee-812e-263021283842" />


### Rationale

The previous p95-only view on coarse buckets was misleading in two ways: sub-30s waits showed up as ~28s due to linear interpolation inside the too-wide first bucket, and a single upper percentile without a central-tendency signal gave no sense of what a normal job experienced. Median + p95 on buckets tuned for queue times — and on separate auto-scaled panels — give a much more honest picture of the system's behaviour.

### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — N/A
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — N/A