### PR TITLE
fix: make hostmetrics dashboard single-runner drilldown

### DIFF
--- a/runner_grafana_dashboards/runner_vm_hostmetrics.json
+++ b/runner_grafana_dashboards/runner_vm_hostmetrics.json
@@ -64,7 +64,7 @@
       }
     ]
   },
-  "description": "Host-level resource metrics (CPU, memory, disk, filesystem, network) for GitHub Actions runner VMs, based on the OpenTelemetry hostmetrics receiver. Filter by repository, workflow, job and runner to inspect a specific run, or pick \"All\" on a variable to widen the scope.",
+  "description": "Single-runner drilldown for host-level resource metrics (CPU, memory, disk, filesystem, network) on GitHub Actions runner VMs, based on the OpenTelemetry hostmetrics receiver. Pick exactly one runner; repository, workflow and job can be used to narrow the runner list.",
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -113,7 +113,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "1 - avg(rate(system_cpu_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"idle\"}[$__rate_interval]))",
+          "expr": "1 - avg(rate(system_cpu_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"idle\"}[$__rate_interval]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -154,7 +154,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "1 - (sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"free\"}) / sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}))",
+          "expr": "1 - (sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"free\"}) / sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -195,7 +195,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "sum(system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",mountpoint=\"/\",state=\"used\"}) / sum(system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",mountpoint=\"/\",state=~\"used|free\"})",
+          "expr": "sum(system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",mountpoint=\"/\",state=\"used\"}) / sum(system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",mountpoint=\"/\",state=~\"used|free\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -229,7 +229,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_cpu_load_average_1m{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}",
+          "expr": "system_cpu_load_average_1m{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -263,7 +263,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "count(count by (cpu) (system_cpu_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}))",
+          "expr": "count(count by (cpu) (system_cpu_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -297,7 +297,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"})",
+          "expr": "sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"})",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -348,7 +348,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "1 - avg(rate(system_cpu_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"idle\"}[$__rate_interval]))",
+          "expr": "1 - avg(rate(system_cpu_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"idle\"}[$__rate_interval]))",
           "legendFormat": "CPU Utilization",
           "range": true,
           "refId": "A"
@@ -398,7 +398,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_cpu_load_average_1m{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}",
+          "expr": "system_cpu_load_average_1m{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}",
           "legendFormat": "1m",
           "range": true,
           "refId": "A"
@@ -406,7 +406,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_cpu_load_average_5m{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}",
+          "expr": "system_cpu_load_average_5m{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}",
           "legendFormat": "5m",
           "range": true,
           "refId": "B"
@@ -414,7 +414,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_cpu_load_average_15m{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}",
+          "expr": "system_cpu_load_average_15m{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}",
           "legendFormat": "15m",
           "range": true,
           "refId": "C"
@@ -422,7 +422,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "count(count by (cpu) (system_cpu_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}))",
+          "expr": "count(count by (cpu) (system_cpu_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}))",
           "legendFormat": "cores",
           "range": true,
           "refId": "D"
@@ -472,7 +472,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"used\"}",
+          "expr": "system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"used\"}",
           "legendFormat": "used",
           "range": true,
           "refId": "A"
@@ -480,7 +480,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"cached\"}",
+          "expr": "system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"cached\"}",
           "legendFormat": "cached",
           "range": true,
           "refId": "B"
@@ -488,7 +488,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"buffered\"}",
+          "expr": "system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"buffered\"}",
           "legendFormat": "buffered",
           "range": true,
           "refId": "C"
@@ -496,7 +496,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"free\"}",
+          "expr": "system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"free\"}",
           "legendFormat": "free",
           "range": true,
           "refId": "D"
@@ -539,7 +539,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "1 - (sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"free\"}) / sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}))",
+          "expr": "1 - (sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"free\"}) / sum(system_memory_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}))",
           "legendFormat": "Memory Utilization",
           "range": true,
           "refId": "A"
@@ -595,7 +595,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_disk_io_bytes_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",direction=\"read\"}[$__rate_interval])",
+          "expr": "rate(system_disk_io_bytes_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",direction=\"read\"}[$__rate_interval])",
           "legendFormat": "{{device}} read",
           "range": true,
           "refId": "A"
@@ -603,7 +603,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_disk_io_bytes_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",direction=\"write\"}[$__rate_interval])",
+          "expr": "rate(system_disk_io_bytes_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",direction=\"write\"}[$__rate_interval])",
           "legendFormat": "{{device}} write",
           "range": true,
           "refId": "B"
@@ -651,7 +651,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_disk_operations_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",direction=\"read\"}[$__rate_interval])",
+          "expr": "rate(system_disk_operations_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",direction=\"read\"}[$__rate_interval])",
           "legendFormat": "{{device}} read",
           "range": true,
           "refId": "A"
@@ -659,7 +659,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_disk_operations_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",direction=\"write\"}[$__rate_interval])",
+          "expr": "rate(system_disk_operations_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",direction=\"write\"}[$__rate_interval])",
           "legendFormat": "{{device}} write",
           "range": true,
           "refId": "B"
@@ -702,7 +702,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_disk_io_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}[$__rate_interval])",
+          "expr": "rate(system_disk_io_time_seconds_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -752,7 +752,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "sum by (mountpoint) (system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"used\"}) / sum by (mountpoint) (system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=~\"used|free\"})",
+          "expr": "sum by (mountpoint) (system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"used\"}) / sum by (mountpoint) (system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=~\"used|free\"})",
           "legendFormat": "{{mountpoint}}",
           "range": true,
           "refId": "A"
@@ -794,7 +794,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"used\"}",
+          "expr": "system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"used\"}",
           "legendFormat": "{{mountpoint}} used",
           "range": true,
           "refId": "A"
@@ -802,7 +802,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",state=\"free\"}",
+          "expr": "system_filesystem_usage_bytes{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",state=\"free\"}",
           "legendFormat": "{{mountpoint}} free",
           "range": true,
           "refId": "B"
@@ -858,7 +858,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_network_io_bytes_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",direction=\"receive\"}[$__rate_interval]) * 8",
+          "expr": "rate(system_network_io_bytes_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",direction=\"receive\"}[$__rate_interval]) * 8",
           "legendFormat": "{{device}} receive",
           "range": true,
           "refId": "A"
@@ -866,7 +866,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_network_io_bytes_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",direction=\"transmit\"}[$__rate_interval]) * 8",
+          "expr": "rate(system_network_io_bytes_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",direction=\"transmit\"}[$__rate_interval]) * 8",
           "legendFormat": "{{device}} transmit",
           "range": true,
           "refId": "B"
@@ -914,7 +914,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_network_packets_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",direction=\"receive\"}[$__rate_interval])",
+          "expr": "rate(system_network_packets_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",direction=\"receive\"}[$__rate_interval])",
           "legendFormat": "{{device}} receive",
           "range": true,
           "refId": "A"
@@ -922,7 +922,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_network_packets_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\",direction=\"transmit\"}[$__rate_interval])",
+          "expr": "rate(system_network_packets_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\",direction=\"transmit\"}[$__rate_interval])",
           "legendFormat": "{{device}} transmit",
           "range": true,
           "refId": "B"
@@ -964,7 +964,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "rate(system_network_errors_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"}[$__rate_interval])",
+          "expr": "rate(system_network_errors_total{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"}[$__rate_interval])",
           "legendFormat": "{{device}} {{direction}} errors",
           "range": true,
           "refId": "A"
@@ -1006,7 +1006,7 @@
         {
           "datasource": {"type": "prometheus", "uid": "${prometheusds}"},
           "editorMode": "code",
-          "expr": "sum by (state) (system_network_connections{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=~\"$github_runner\"})",
+          "expr": "sum by (state) (system_network_connections{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\",github_runner=\"$github_runner\"})",
           "legendFormat": "{{state}}",
           "range": true,
           "refId": "A"
@@ -1081,9 +1081,8 @@
         "query": "label_values(system_cpu_load_average_1m{github_repository=~\"$github_repository\",github_workflow=~\"$github_workflow\",github_job=~\"$github_job\"}, github_runner)",
         "refresh": 2,
         "sort": 1,
-        "includeAll": true,
+        "includeAll": false,
         "multi": false,
-        "allValue": ".*",
         "hide": 0
       }
     ]


### PR DESCRIPTION
#### What this PR does

Reframes the runner VM hostmetrics Grafana dashboard from a multi-runner overview into a single-runner drilldown.

- The `github_runner` template variable now requires a single selection (`includeAll: false`, `allValue` removed).
- All 28 PromQL queries change `github_runner=~"$github_runner"` → `github_runner="$github_runner"` so panels chart one host instead of overlaying every match.
- Repo/workflow/job filters stay regex-matched and still default to "All" — they now act as a way to narrow the runner picker.
- Dashboard description updated to reflect the new behavior.

#### Why we need it

With more than a handful of active runners, the dashboard overlaid every series in scope on each panel, making it unreadable by default. Forcing a single-runner selection makes the panels useful out of the box; users still reach the runner they care about via the repo/workflow/job filters.

#### Screenshot

<img width="3263" height="1926" alt="pic" src="https://github.com/user-attachments/assets/824be759-d93f-4bf6-8ee0-317db2a9e366" />

#### Test plan

- Loaded the modified dashboard JSON in Grafana against the COS Prometheus datasource.
- Verified the runner dropdown no longer offers "All" and forces a single value.
- Confirmed each panel renders one series per device/mountpoint/state for the selected runner.

#### Review focus

- The `github_runner` label match changed from `=~` to `=`. Emitted values are GitHub runner hostnames, so regex-metachar collisions are not expected, but worth a sanity check.
- Dashboard description copy.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — n/a
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — n/a, only dashboard JSON changed
- [ ] I updated `docs/changelog.md` with user-relevant changes — n/a, changelog scope is the Planner and Webhook gateway charms
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration) — n/a, dashboard JSON is not covered by tests
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct) — n/a
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard — pending: drop /tmp/pic.png into the Screenshot section above before marking ready for review
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors — n/a
- [ ] **If this PR involves Rockcraft:** I updated the version — n/a