### PR TITLE
docs: update the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub runner operators
 
-This repository contains applications, juju charms, Grafana dashboards and actions related to operating and using
+This repository contains applications, Juju charms, Grafana dashboards and actions related to operating and using
 self-hosted GitHub Actions runners.
 
 

--- a/README.md
+++ b/README.md
@@ -7,40 +7,26 @@ self-hosted GitHub Actions runners.
 ## Repository layout
 
 ```
+actions/
+  enable-log-forwarding/    # GitHub Action: enable log forwarding on runners
+
 charms/
   planner-operator/         # Juju charm: GitHub runner planner
     cos_custom/
       grafana_dashboards/   # Grafana dashboards for the planner charm
-                            # (served via cos-configuration-k8s, path: charms/planner-operator/cos_custom/grafana_dashboards)
   webhook-gateway-operator/ # Juju charm: GitHub webhook gateway
 
+cmd/
+  planner/                  # Application entry point: planner
+  webhook-gateway/          # Application entry point: webhook gateway
+
+internal/                   # Shared Go packages
+
+docs/                       # Documentation
+
 runner_grafana_dashboards/  # Grafana dashboards for runner VM host metrics
-                            # (served via cos-configuration-k8s, path: runner_grafana_dashboards)
 ```
 
 ## Further information
 
 Further information can be found in the `docs/` directory.
-
-
-## Observability: Grafana dashboards
-
-Dashboards in this repo are delivered to Grafana through
-[`cos-configuration-k8s`](https://charmhub.io/cos-configuration-k8s), which syncs
-JSON files from this Git repository and provisions them via the `grafana-dashboard`
-relation. Provisioned dashboards are **immutable** in Grafana regardless of user
-role — they cannot be edited or deleted through the UI.
-
-### Conventions
-
-| Directory | Purpose | `grafana_dashboards_path` config value |
-|---|---|---|
-| `charms/<charm>/cos_custom/grafana_dashboards/` | Dashboards for a specific charm's workload metrics | `charms/<charm>/cos_custom/grafana_dashboards` |
-| `runner_grafana_dashboards/` | Dashboards for runner VM host-level metrics (CPU, memory, disk, network) | `runner_grafana_dashboards` |
-
-Dashboard JSON files should use `__inputs` to declare the datasource (type `prometheus`).
-Setting `"editable": false` is recommended for clarity, but is not strictly required:
-dashboards delivered through `cos-configuration-k8s` are filesystem-provisioned and
-therefore read-only in Grafana regardless of the JSON flag. Metric names follow the
-[OpenTelemetry hostmetrics receiver](https://opentelemetry.io/docs/collector/components/#receiver)
-Prometheus naming convention (e.g. `system_cpu_time_seconds_total`).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GitHub runner operators
 
-![WIP](https://img.shields.io/badge/status-WIP-yellow)
+This repository contains applications, juju charms, Grafana dashboards and actions related to operating and using
+self-hosted GitHub Actions runners.
 
-A monorepo containing charms to operate Self-Hosted GitHub Action Runners.
 
 ## Repository layout
 
@@ -17,6 +17,11 @@ charms/
 runner_grafana_dashboards/  # Grafana dashboards for runner VM host metrics
                             # (served via cos-configuration-k8s, path: runner_grafana_dashboards)
 ```
+
+## Further information
+
+Further information can be found in the `docs/` directory.
+
 
 ## Observability: Grafana dashboards
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ self-hosted GitHub Actions runners.
 
 ## Repository layout
 
+The Go application code (`cmd/`, `internal/`) follows the
+[community Go project layout](https://github.com/golang-standards/project-layout).
+
 ```
 actions/
   enable-log-forwarding/    # GitHub Action: enable log forwarding on runners
@@ -29,12 +32,10 @@ runner_grafana_dashboards/  # Grafana dashboards for runner VM host metrics
 
 ## Charms
 
-- **planner-operator** (`charms/planner-operator/`): tells the GitHub runner
-  charm how many runners of each type to deploy, based on incoming workflow
-  job events.
-- **webhook-gateway-operator** (`charms/webhook-gateway-operator/`): receives
-  GitHub webhooks and forwards workflow job events to a message broker for the
-  planner to consume.
+This repository contains two charms — the **planner-operator** and the
+**webhook-gateway-operator**. See
+[Charms](https://documentation.ubuntu.com/github-runner-operators/latest/reference/charms/)
+in the documentation for their roles and integrations.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,40 @@ docs/                       # Documentation
 runner_grafana_dashboards/  # Grafana dashboards for runner VM host metrics
 ```
 
-## Further information
+## Charms
 
-Further information can be found in the `docs/` directory.
+- **planner-operator** (`charms/planner-operator/`): tells the GitHub runner
+  charm how many runners of each type to deploy, based on incoming workflow
+  job events.
+- **webhook-gateway-operator** (`charms/webhook-gateway-operator/`): receives
+  GitHub webhooks and forwards workflow job events to a message broker for the
+  planner to consume.
+
+## Documentation
+
+Our documentation is stored in the `docs` directory.
+It is based on the Canonical starter pack
+and hosted on [Read the Docs](https://documentation.ubuntu.com/github-runner-operators/latest/).
+In structuring, the documentation employs the [Diátaxis](https://diataxis.fr/) approach.
+
+You may open a pull request with your documentation changes, or you can
+[file a bug](https://github.com/canonical/github-runner-operators/issues) to provide constructive feedback or suggestions.
+
+To run the documentation locally before submitting your changes:
+
+```bash
+cd docs
+make run
+```
+
+GitHub runs automatic checks on the documentation
+to verify spelling, validate links and style guide compliance.
+
+You can (and should) run the same checks locally:
+
+```bash
+make spelling
+make linkcheck
+make vale
+make lint-md
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 # Changelog
 
-This changelog documents user-relevant changes to the Planner charm and Webhook gateway charm.
+This changelog documents user-relevant changes across this repository (charms, applications, GitHub Actions, and dashboards).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 

--- a/docs/reference/grafana-dashboards.md
+++ b/docs/reference/grafana-dashboards.md
@@ -11,5 +11,5 @@
 
 Dashboard JSON files should use `__inputs` to declare the data source (type `prometheus`).
 Setting `"editable": false` is recommended for clarity. Metric names follow the
-[OpenTelemetry host metrics receiver](https://opentelemetry.io/docs/collector/components/receiver/)
+[OpenTelemetry host metrics receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver)
 Prometheus naming convention (for example, `system_cpu_time_seconds_total`).

--- a/docs/reference/grafana-dashboards.md
+++ b/docs/reference/grafana-dashboards.md
@@ -12,4 +12,4 @@
 Dashboard JSON files should use `__inputs` to declare the datasource (type `prometheus`).
 Setting `"editable": false` is recommended for clarity. Metric names follow the
 [OpenTelemetry hostmetrics receiver](https://opentelemetry.io/docs/collector/components/#receiver)
-Prometheus naming convention (e.g. `system_cpu_time_seconds_total`).
+Prometheus naming convention (for example, `system_cpu_time_seconds_total`).

--- a/docs/reference/grafana-dashboards.md
+++ b/docs/reference/grafana-dashboards.md
@@ -9,7 +9,7 @@
 
 ## Conventions
 
-Dashboard JSON files should use `__inputs` to declare the datasource (type `prometheus`).
+Dashboard JSON files should use `__inputs` to declare the data source (type `prometheus`).
 Setting `"editable": false` is recommended for clarity. Metric names follow the
-[OpenTelemetry hostmetrics receiver](https://opentelemetry.io/docs/collector/components/#receiver)
+[OpenTelemetry host metrics receiver](https://opentelemetry.io/docs/collector/components/receiver/)
 Prometheus naming convention (for example, `system_cpu_time_seconds_total`).

--- a/docs/reference/grafana-dashboards.md
+++ b/docs/reference/grafana-dashboards.md
@@ -1,0 +1,15 @@
+# Grafana dashboards
+
+## Dashboard directories
+
+| Directory | Purpose |
+|---|---|
+| `charms/<charm>/cos_custom/grafana_dashboards/` | Dashboards for a specific charm's workload metrics |
+| `runner_grafana_dashboards/` | Dashboards for runner VM host-level metrics (CPU, memory, disk, network) |
+
+## Conventions
+
+Dashboard JSON files should use `__inputs` to declare the datasource (type `prometheus`).
+Setting `"editable": false` is recommended for clarity. Metric names follow the
+[OpenTelemetry hostmetrics receiver](https://opentelemetry.io/docs/collector/components/#receiver)
+Prometheus naming convention (e.g. `system_cpu_time_seconds_total`).

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -11,3 +11,4 @@ Contents
 
    architecture
    charms
+   grafana-dashboards


### PR DESCRIPTION
#### What this PR does

Update the README with purpose and structure of the repo, and move Grafana dashboard conventions to a new reference doc page.

#### Why we need it

The README is not providing a lot of information and is still marking the repo as WIP, though the charms are already used in production.

#### Checklist

- [ ] Changes comply with the project&#39;s coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run)
- [x] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR involves Rockcraft:** I updated the version



