### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/publish_charms.yml
+++ b/.github/workflows/publish_charms.yml
@@ -3,7 +3,7 @@ name: Publish to edge
 on:
   push:
     branches:
-      - main
+    - main
   # We also run on pull_request to ensure build process is working, but the final publish will be skipped for pull_request
   pull_request:
 
@@ -17,105 +17,111 @@ jobs:
       fail-fast: false
       matrix:
         charm:
-          - planner
-          - webhook-gateway
+        - planner
+        - webhook-gateway
+    permissions:
+      actions: read
+      contents: write
     name: ${{ github.event_name == 'push' && '' || 'Test ' }}Publish Charm (${{ matrix.charm }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - name: Remove Android SDK
-        run: sudo rm -rf /usr/local/lib/android
-      - name: setup lxd
-        uses: canonical/setup-lxd@v1
-      - name: rename ${{ matrix.charm }}-rockcraft.yaml
-        run: |
-          mv ${{ matrix.charm }}-rockcraft.yaml rockcraft.yaml
-      - name: build rock
-        id: rockcraft
-        run: |
-          sudo snap install --channel latest/stable --classic rockcraft
-          rockcraft pack --verbosity trace
-          echo rock=`ls *.rock` >> $GITHUB_OUTPUT
-      - run: |
-          echo rockcraft pack:
-          echo ${{ steps.rockcraft.outputs.rock }}
-      - name: upload rock
-        run: |
-          docker run -d -p 5000:5000 --name registry registry:latest
-          rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:${{ steps.rockcraft.outputs.rock }} docker://localhost:5000/rock:latest
-      - name: build charm
-        id: charmcraft
-        working-directory: charms/${{ matrix.charm }}-operator/
-        run: |
-          sudo snap install --channel latest/stable --classic charmcraft
-          charmcraft pack --verbosity trace
-          echo charms=`ls -d $PWD/*.charm` >> $GITHUB_OUTPUT
-      - run: |
-          echo charmcraft pack:
-          echo ${{ steps.charmcraft.outputs.charms }}
-      - id: charm-name
-        working-directory: charms/${{ matrix.charm }}-operator/
-        run: |
-          echo charm-name=`yq -r .name charmcraft.yaml` >> $GITHUB_OUTPUT
-      - run: |
-          sudo apt update && sudo apt install python3-yaml -y
-      - name: update upstream-source
-        working-directory: charms/${{ matrix.charm }}-operator/
-        shell: python
-        run: |
-          import os
-          import subprocess
+    - uses: actions/checkout@v6.0.2
+    - name: Remove Android SDK
+      run: sudo rm -rf /usr/local/lib/android
+    - name: setup lxd
+      uses: canonical/setup-lxd@v1
+    - name: rename ${{ matrix.charm }}-rockcraft.yaml
+      run: |
+        mv ${{ matrix.charm }}-rockcraft.yaml rockcraft.yaml
+    - name: build rock
+      id: rockcraft
+      run: |
+        sudo snap install --channel latest/stable --classic rockcraft
+        rockcraft pack --verbosity trace
+        echo rock=`ls *.rock` >> $GITHUB_OUTPUT
+    - run: |
+        echo rockcraft pack:
+        echo ${{ steps.rockcraft.outputs.rock }}
+    - name: upload rock
+      run: |
+        docker run -d -p 5000:5000 --name registry registry:latest
+        rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:${{ steps.rockcraft.outputs.rock }} docker://localhost:5000/rock:latest
+    - name: build charm
+      id: charmcraft
+      working-directory: charms/${{ matrix.charm }}-operator/
+      run: |
+        sudo snap install --channel latest/stable --classic charmcraft
+        charmcraft pack --verbosity trace
+        echo charms=`ls -d $PWD/*.charm` >> $GITHUB_OUTPUT
+    - run: |
+        echo charmcraft pack:
+        echo ${{ steps.charmcraft.outputs.charms }}
+    - id: charm-name
+      working-directory: charms/${{ matrix.charm }}-operator/
+      run: |
+        echo charm-name=`yq -r .name charmcraft.yaml` >> $GITHUB_OUTPUT
+    - run: |
+        sudo apt update && sudo apt install python3-yaml -y
+    - name: update upstream-source
+      working-directory: charms/${{ matrix.charm }}-operator/
+      shell: python
+      run: |
+        import os
+        import subprocess
 
-          import yaml
+        import yaml
 
-          expanded_charmcraft_yaml = subprocess.check_output(
-            ["charmcraft", "expand-extensions"],
-            env={**os.environ, "CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS": "true"}
-          )
-          charmcraft_yaml = yaml.safe_load(expanded_charmcraft_yaml)
-          resources = charmcraft_yaml["resources"]
-          resources[list(resources)[0]]["upstream-source"] = "localhost:5000/rock:latest"
-          yaml.dump(charmcraft_yaml, open("charmcraft.yaml", "w"), sort_keys=False)
-      - working-directory: charms/${{ matrix.charm }}-operator/
-        run: |
-          echo upload charm ${{ steps.charm-name.outputs.charm-name }}
-      - working-directory: charms/${{ matrix.charm }}-operator/
-        run: |
-          cat charmcraft.yaml
-      - if: github.event_name == 'push'
-        name: publish charm
-        uses: canonical/charming-actions/upload-charm@2.7.0
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          built-charm-path: ${{ steps.charmcraft.outputs.charms }}
-          tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
-          charm-path: charms/${{ matrix.charm }}-operator
+        expanded_charmcraft_yaml = subprocess.check_output(
+          ["charmcraft", "expand-extensions"],
+          env={**os.environ, "CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS": "true"}
+        )
+        charmcraft_yaml = yaml.safe_load(expanded_charmcraft_yaml)
+        resources = charmcraft_yaml["resources"]
+        resources[list(resources)[0]]["upstream-source"] = "localhost:5000/rock:latest"
+        yaml.dump(charmcraft_yaml, open("charmcraft.yaml", "w"), sort_keys=False)
+    - working-directory: charms/${{ matrix.charm }}-operator/
+      run: |
+        echo upload charm ${{ steps.charm-name.outputs.charm-name }}
+    - working-directory: charms/${{ matrix.charm }}-operator/
+      run: |
+        cat charmcraft.yaml
+    - if: github.event_name == 'push'
+      name: publish charm
+      uses: canonical/charming-actions/upload-charm@2.7.0
+      with:
+        credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        built-charm-path: ${{ steps.charmcraft.outputs.charms }}
+        tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
+        charm-path: charms/${{ matrix.charm }}-operator
 
   publish-garm-configurator:
     name: ${{ github.event_name == 'push' && '' || 'Test ' }}Publish Charm (garm-configurator)
+    permissions:
+      actions: read
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - name: setup lxd
-        uses: canonical/setup-lxd@v1
-      - name: build charm
-        id: charmcraft
-        working-directory: charms/garm-configurator/
-        run: |
-          sudo snap install --channel latest/stable --classic charmcraft
-          charmcraft pack --verbosity trace
-          echo charms=`ls -d $PWD/*.charm` >> $GITHUB_OUTPUT
-      - id: charm-name
-        working-directory: charms/garm-configurator/
-        run: |
-          echo charm-name=`yq -r .name charmcraft.yaml` >> $GITHUB_OUTPUT
-      - if: github.event_name == 'push'
-        name: publish charm
-        uses: canonical/charming-actions/upload-charm@2.7.0
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          built-charm-path: ${{ steps.charmcraft.outputs.charms }}
-          tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
-          charm-path: charms/garm-configurator
+    - uses: actions/checkout@v6.0.2
+    - name: setup lxd
+      uses: canonical/setup-lxd@v1
+    - name: build charm
+      id: charmcraft
+      working-directory: charms/garm-configurator/
+      run: |
+        sudo snap install --channel latest/stable --classic charmcraft
+        charmcraft pack --verbosity trace
+        echo charms=`ls -d $PWD/*.charm` >> $GITHUB_OUTPUT
+    - id: charm-name
+      working-directory: charms/garm-configurator/
+      run: |
+        echo charm-name=`yq -r .name charmcraft.yaml` >> $GITHUB_OUTPUT
+    - if: github.event_name == 'push'
+      name: publish charm
+      uses: canonical/charming-actions/upload-charm@2.7.0
+      with:
+        credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        built-charm-path: ${{ steps.charmcraft.outputs.charms }}
+        tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
+        charm-path: charms/garm-configurator

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -78,3 +78,4 @@ Makefile
 rediraffe
 retrigger(ing)?
 Diátaxis
+hostmetrics


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.