### PR TITLE
feat: enable Terraform testing in workflow

### DIFF
--- a/.github/workflows/test_terraform_garm_configurator_module.yaml
+++ b/.github/workflows/test_terraform_garm_configurator_module.yaml
@@ -22,6 +22,7 @@ jobs:
           filters: |
             terraform:
               - "**/terraform/**"
+              - ".github/workflows/test_terraform_garm_configurator_module.yaml"
 
   test-terraform:
     needs: detect-changes

--- a/.github/workflows/test_terraform_garm_configurator_module.yaml
+++ b/.github/workflows/test_terraform_garm_configurator_module.yaml
@@ -25,8 +25,7 @@ jobs:
 
   test-terraform:
     needs: detect-changes
-    # garm-configurator is not yet published to Charmhub; enable once published.
-    if: false
+    if: needs.detect-changes.outputs.terraform == 'true'
     name: Test Terraform with Juju
     runs-on: self-hosted-linux-amd64-noble-edge
     env:


### PR DESCRIPTION
#### What this PR does
Enable the terraform module test workflow for garm configurator charm

#### Why we need it
Previously it was disabled. Right now we have to enable it sinice the garm configurator charm has been published.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run)
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [x] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR involves Rockcraft:** I updated the version

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

