### PR TITLE
fix(rock): embed GARM version via git describe in ldflags

### DIFF
--- a/garm-rockcraft.yaml
+++ b/garm-rockcraft.yaml
@@ -24,7 +24,10 @@ parts:
       - GOTOOLCHAIN: local
     override-build: |
       cd "$CRAFT_PART_SRC"
-      go build -tags osusergo,netgo,sqlite_omit_load_extension -ldflags "-extldflags -static" -o bin/garm ./cmd/garm
+      VERSION=$(git describe --tags --match='v[0-9]*' --always)
+      go build -tags osusergo,netgo,sqlite_omit_load_extension \
+        -ldflags "-extldflags -static -X github.com/cloudbase/garm/util/appdefaults.Version=${VERSION}" \
+        -o bin/garm ./cmd/garm
       mkdir -p "$CRAFT_PART_INSTALL/usr/local/bin"
       cp bin/garm "$CRAFT_PART_INSTALL/usr/local/bin/"
 


### PR DESCRIPTION
## Problem

The `garm` binary reports `v0.0.0-unknown` because the build does not inject version information via ldflags.

## Fix

Use `git describe --tags --match='v[0-9]*' --always` at build time to extract the version from the checked-out source tag, then pass it via `-X github.com/cloudbase/garm/util/appdefaults.Version=${VERSION}`. This matches upstream's Makefile approach.

When Renovate bumps `source-tag` (e.g. `v0.2.1` → `v0.3.0`), the embedded version automatically follows — no second field to maintain.