### PR TITLE
Add scaleset configurations

### DIFF
--- a/charms/garm-configurator/charmcraft.yaml
+++ b/charms/garm-configurator/charmcraft.yaml
@@ -63,6 +63,50 @@ config:
       description: |
         Juju secret containing the GitHub App private key (PEM format).
         The secret content must have a "value" key with the private key string.
+    name:
+      type: string
+      description: |
+        The name of the scaleset.
+    flavor:
+      type: string
+      description: |
+        The resource flavor to use for runners in the scaleset.
+    os-arch:
+      type: string
+      description: |
+        The CPU architecture for runners in the scaleset.
+    min-idle-runner:
+      type: int
+      default: 0
+      description: |
+        Minimum number of idle runners in the scaleset.
+    max-runner:
+      type: int
+      default: 0
+      description: |
+        Maximum number of runners in the scaleset.
+    labels:
+      type: string
+      description: |
+        Comma-separated list of labels to add to runners.
+    repo:
+      type: string
+      description: |
+        Repository to register runners to. Mutually exclusive with org and runner-group.
+    org:
+      type: string
+      description: |
+        Organization to register runners to. Mutually exclusive with repo.
+    runner-group:
+      type: string
+      default: default
+      description: |
+        Runner group for org registration. Only used when org is set.
+    pre-install-scripts:
+      type: string
+      description: |
+        A Python dict-like string containing key-value pairs of script name
+        to bash script to be run prior to runner installation.
 
 parts:
   charm:

--- a/charms/garm-configurator/charmcraft.yaml
+++ b/charms/garm-configurator/charmcraft.yaml
@@ -92,7 +92,7 @@ config:
     repo:
       type: string
       description: |
-        Repository to register runners to. Mutually exclusive with org and runner-group.
+        Repository to register runners to. Mutually exclusive with org.
     org:
       type: string
       description: |
@@ -101,7 +101,7 @@ config:
       type: string
       default: default
       description: |
-        Runner group for org registration. Only used when org is set.
+        Runner group for org registration. Ignored when repo is set.
     pre-install-scripts:
       type: string
       description: |

--- a/charms/garm-configurator/src/charm_state.py
+++ b/charms/garm-configurator/src/charm_state.py
@@ -248,6 +248,11 @@ class ScalesetConfig(BaseModel):
             raise CharmConfigInvalidError(
                 f"{SCALESET_MAX_RUNNER_CONFIG_NAME} must be non-negative"
             )
+        if max_runner < min_idle_runner:
+            raise CharmConfigInvalidError(
+                f"{SCALESET_MAX_RUNNER_CONFIG_NAME} must be greater than or equal to "
+                f"{SCALESET_MIN_IDLE_RUNNER_CONFIG_NAME}"
+            )
 
         repo = charm.config.get(SCALESET_REPO_CONFIG_NAME)
         repo = str(repo).strip() if repo else None

--- a/charms/garm-configurator/src/charm_state.py
+++ b/charms/garm-configurator/src/charm_state.py
@@ -274,9 +274,9 @@ class ScalesetConfig(BaseModel):
         pre_install_scripts = str(pre_install_scripts) if pre_install_scripts else None
 
         return cls(
-            name=str(charm.config.get(SCALESET_NAME_CONFIG_NAME)),
-            flavor=str(charm.config.get(SCALESET_FLAVOR_CONFIG_NAME)),
-            os_arch=str(charm.config.get(SCALESET_OS_ARCH_CONFIG_NAME)),
+            name=str(charm.config.get(SCALESET_NAME_CONFIG_NAME)).strip(),
+            flavor=str(charm.config.get(SCALESET_FLAVOR_CONFIG_NAME)).strip(),
+            os_arch=str(charm.config.get(SCALESET_OS_ARCH_CONFIG_NAME)).strip()
             min_idle_runner=min_idle_runner,
             max_runner=max_runner,
             labels=labels,

--- a/charms/garm-configurator/src/charm_state.py
+++ b/charms/garm-configurator/src/charm_state.py
@@ -274,7 +274,7 @@ class ScalesetConfig(BaseModel):
         return cls(
             name=str(charm.config.get(SCALESET_NAME_CONFIG_NAME)).strip(),
             flavor=str(charm.config.get(SCALESET_FLAVOR_CONFIG_NAME)).strip(),
-            os_arch=str(charm.config.get(SCALESET_OS_ARCH_CONFIG_NAME)).strip()
+            os_arch=str(charm.config.get(SCALESET_OS_ARCH_CONFIG_NAME)).strip(),
             min_idle_runner=min_idle_runner,
             max_runner=max_runner,
             labels=labels,

--- a/charms/garm-configurator/src/charm_state.py
+++ b/charms/garm-configurator/src/charm_state.py
@@ -19,6 +19,17 @@ GITHUB_APP_CLIENT_ID_CONFIG_NAME = "github-app-client-id"
 GITHUB_APP_INSTALLATION_ID_CONFIG_NAME = "github-app-installation-id"
 GITHUB_APP_PRIVATE_KEY_CONFIG_NAME = "github-app-private-key"  # nosec
 
+SCALESET_NAME_CONFIG_NAME = "name"
+SCALESET_FLAVOR_CONFIG_NAME = "flavor"
+SCALESET_OS_ARCH_CONFIG_NAME = "os-arch"
+SCALESET_MIN_IDLE_RUNNER_CONFIG_NAME = "min-idle-runner"
+SCALESET_MAX_RUNNER_CONFIG_NAME = "max-runner"
+SCALESET_LABELS_CONFIG_NAME = "labels"
+SCALESET_REPO_CONFIG_NAME = "repo"
+SCALESET_ORG_CONFIG_NAME = "org"
+SCALESET_RUNNER_GROUP_CONFIG_NAME = "runner-group"
+SCALESET_PRE_INSTALL_SCRIPTS_CONFIG_NAME = "pre-install-scripts"
+
 
 class CharmConfigInvalidError(Exception):
     """Raised when charm configuration is invalid.
@@ -176,12 +187,113 @@ class GithubAppConfig(BaseModel):
         )
 
 
+class ScalesetConfig(BaseModel):
+    """Scaleset configuration.
+
+    Attributes:
+        name: The name of the scaleset.
+        flavor: The resource flavor for runners.
+        os_arch: The CPU architecture for runners.
+        min_idle_runner: Minimum number of idle runners.
+        max_runner: Maximum number of runners.
+        labels: Comma-separated list of labels for runners.
+        repo: Repository to register runners to.
+        org: Organization to register runners to.
+        runner_group: Runner group for org registration.
+        pre_install_scripts: Script name to bash script pairs for pre-installation.
+    """
+
+    name: str
+    flavor: str
+    os_arch: str
+    min_idle_runner: int
+    max_runner: int
+    labels: str = ""
+    repo: str | None = None
+    org: str | None = None
+    runner_group: str = "default"
+    pre_install_scripts: str | None = None
+
+    @classmethod
+    def from_charm(cls, charm: ops.CharmBase) -> "ScalesetConfig":
+        """Initialize the scaleset config from charm.
+
+        Args:
+            charm: The charm instance.
+
+        Raises:
+            CharmConfigInvalidError: If any configuration is missing or invalid.
+
+        Returns:
+            The parsed scaleset configuration.
+        """
+        required_string_configs = (
+            SCALESET_NAME_CONFIG_NAME,
+            SCALESET_FLAVOR_CONFIG_NAME,
+            SCALESET_OS_ARCH_CONFIG_NAME,
+        )
+        for key in required_string_configs:
+            value = charm.config.get(key)
+            if not value or not str(value).strip():
+                raise CharmConfigInvalidError(f"Missing required configuration: {key}")
+
+        min_idle_runner = int(charm.config.get(SCALESET_MIN_IDLE_RUNNER_CONFIG_NAME, 0))
+        if min_idle_runner < 0:
+            raise CharmConfigInvalidError(
+                f"{SCALESET_MIN_IDLE_RUNNER_CONFIG_NAME} must be non-negative"
+            )
+
+        max_runner = int(charm.config.get(SCALESET_MAX_RUNNER_CONFIG_NAME, 0))
+        if max_runner < 0:
+            raise CharmConfigInvalidError(
+                f"{SCALESET_MAX_RUNNER_CONFIG_NAME} must be non-negative"
+            )
+
+        repo = charm.config.get(SCALESET_REPO_CONFIG_NAME)
+        repo = str(repo).strip() if repo else None
+        org = charm.config.get(SCALESET_ORG_CONFIG_NAME)
+        org = str(org).strip() if org else None
+        runner_group = str(
+            charm.config.get(SCALESET_RUNNER_GROUP_CONFIG_NAME, "default")
+        ).strip()
+
+        if repo and org:
+            raise CharmConfigInvalidError(
+                f"{SCALESET_REPO_CONFIG_NAME} and {SCALESET_ORG_CONFIG_NAME} "
+                f"are mutually exclusive"
+            )
+        if not repo and not org:
+            raise CharmConfigInvalidError(
+                f"At least one of {SCALESET_REPO_CONFIG_NAME} or "
+                f"{SCALESET_ORG_CONFIG_NAME} must be provided"
+            )
+
+        labels = charm.config.get(SCALESET_LABELS_CONFIG_NAME)
+        labels = str(labels).strip() if labels else ""
+        pre_install_scripts = charm.config.get(SCALESET_PRE_INSTALL_SCRIPTS_CONFIG_NAME)
+        pre_install_scripts = str(pre_install_scripts) if pre_install_scripts else None
+
+        return cls(
+            name=str(charm.config.get(SCALESET_NAME_CONFIG_NAME)),
+            flavor=str(charm.config.get(SCALESET_FLAVOR_CONFIG_NAME)),
+            os_arch=str(charm.config.get(SCALESET_OS_ARCH_CONFIG_NAME)),
+            min_idle_runner=min_idle_runner,
+            max_runner=max_runner,
+            labels=labels,
+            repo=repo,
+            org=org,
+            runner_group=runner_group,
+            pre_install_scripts=pre_install_scripts,
+        )
+
+
 class CharmState:
     """The charm state.
 
     Attributes:
         provider_config: OpenStack provider configuration.
         github_app_config: GitHub App configuration.
+        scaleset_config: Scaleset configuration.
     """
 
     def __init__(
@@ -189,15 +301,18 @@ class CharmState:
         *,
         provider_config: ProviderConfig,
         github_app_config: GithubAppConfig,
+        scaleset_config: ScalesetConfig,
     ) -> None:
         """Initialize the charm state.
 
         Args:
             provider_config: The OpenStack provider configuration.
             github_app_config: The GitHub App configuration.
+            scaleset_config: The scaleset configuration.
         """
         self.provider_config = provider_config
         self.github_app_config = github_app_config
+        self.scaleset_config = scaleset_config
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "CharmState":
@@ -214,7 +329,9 @@ class CharmState:
         """
         provider_config = ProviderConfig.from_charm(charm)
         github_app_config = GithubAppConfig.from_charm(charm)
+        scaleset_config = ScalesetConfig.from_charm(charm)
         return cls(
             provider_config=provider_config,
             github_app_config=github_app_config,
+            scaleset_config=scaleset_config,
         )

--- a/charms/garm-configurator/src/charm_state.py
+++ b/charms/garm-configurator/src/charm_state.py
@@ -253,9 +253,7 @@ class ScalesetConfig(BaseModel):
         repo = str(repo).strip() if repo else None
         org = charm.config.get(SCALESET_ORG_CONFIG_NAME)
         org = str(org).strip() if org else None
-        runner_group = str(
-            charm.config.get(SCALESET_RUNNER_GROUP_CONFIG_NAME, "default")
-        ).strip()
+        runner_group = str(charm.config.get(SCALESET_RUNNER_GROUP_CONFIG_NAME, "default")).strip()
 
         if repo and org:
             raise CharmConfigInvalidError(

--- a/charms/garm-configurator/tests/unit/test_charm.py
+++ b/charms/garm-configurator/tests/unit/test_charm.py
@@ -31,6 +31,12 @@ def _valid_config(secret: Secret, private_key_secret: Secret) -> dict:
         "github-app-client-id": "12345",
         "github-app-installation-id": "67890",
         "github-app-private-key": private_key_secret.id,
+        "name": "my-scaleset",
+        "flavor": "m1.large",
+        "os-arch": "amd64",
+        "min-idle-runner": 0,
+        "max-runner": 5,
+        "repo": "myorg/myrepo",
     }
 
 
@@ -72,6 +78,9 @@ _MISSING_CONFIG_SENTINEL = object()
             _MISSING_CONFIG_SENTINEL,
             id="missing-github-app-private-key",
         ),
+        pytest.param("name", _MISSING_CONFIG_SENTINEL, id="missing-name"),
+        pytest.param("flavor", "", id="empty-flavor"),
+        pytest.param("os-arch", "   ", id="whitespace-only-os-arch"),
     ],
 )
 def test_charm_blocked_missing_or_empty_config(config_key: str, override_value: object):
@@ -193,3 +202,104 @@ def test_charm_blocked_github_app_private_key_secret_not_found():
     assert out.unit_status == ops.BlockedStatus(
         "github-app-private-key secret is invalid or missing 'value' key"
     )
+
+
+def test_charm_blocked_negative_min_idle_runner():
+    """
+    arrange: min-idle-runner is negative.
+    act: Run config-changed.
+    assert: Unit status is Blocked.
+    """
+    ctx = Context(GarmConfiguratorCharm)
+    secret = _make_secret()
+    pk_secret = _make_private_key_secret()
+    config = _valid_config(secret, pk_secret)
+    config["min-idle-runner"] = -1
+    state = State(config=config, secrets=[secret, pk_secret])
+    out = ctx.run(ctx.on.config_changed(), state)
+    assert out.unit_status == ops.BlockedStatus("min-idle-runner must be non-negative")
+
+
+def test_charm_blocked_negative_max_runner():
+    """
+    arrange: max-runner is negative.
+    act: Run config-changed.
+    assert: Unit status is Blocked.
+    """
+    ctx = Context(GarmConfiguratorCharm)
+    secret = _make_secret()
+    pk_secret = _make_private_key_secret()
+    config = _valid_config(secret, pk_secret)
+    config["max-runner"] = -5
+    state = State(config=config, secrets=[secret, pk_secret])
+    out = ctx.run(ctx.on.config_changed(), state)
+    assert out.unit_status == ops.BlockedStatus("max-runner must be non-negative")
+
+
+def test_charm_blocked_neither_repo_nor_org():
+    """
+    arrange: Neither repo nor org is set.
+    act: Run config-changed.
+    assert: Unit status is Blocked.
+    """
+    ctx = Context(GarmConfiguratorCharm)
+    secret = _make_secret()
+    pk_secret = _make_private_key_secret()
+    config = _valid_config(secret, pk_secret)
+    del config["repo"]
+    state = State(config=config, secrets=[secret, pk_secret])
+    out = ctx.run(ctx.on.config_changed(), state)
+    assert out.unit_status == ops.BlockedStatus(
+        "At least one of repo or org must be provided"
+    )
+
+
+def test_charm_blocked_repo_and_org_both_set():
+    """
+    arrange: Both repo and org are set.
+    act: Run config-changed.
+    assert: Unit status is Blocked.
+    """
+    ctx = Context(GarmConfiguratorCharm)
+    secret = _make_secret()
+    pk_secret = _make_private_key_secret()
+    config = _valid_config(secret, pk_secret)
+    config["org"] = "myorg"
+    state = State(config=config, secrets=[secret, pk_secret])
+    out = ctx.run(ctx.on.config_changed(), state)
+    assert out.unit_status == ops.BlockedStatus("repo and org are mutually exclusive")
+
+
+def test_charm_active_with_org_and_runner_group():
+    """
+    arrange: org and runner-group are set (no repo).
+    act: Run config-changed.
+    assert: Unit status is Active.
+    """
+    ctx = Context(GarmConfiguratorCharm)
+    secret = _make_secret()
+    pk_secret = _make_private_key_secret()
+    config = _valid_config(secret, pk_secret)
+    del config["repo"]
+    config["org"] = "myorg"
+    config["runner-group"] = "my-group"
+    state = State(config=config, secrets=[secret, pk_secret])
+    out = ctx.run(ctx.on.config_changed(), state)
+    assert out.unit_status == ops.ActiveStatus("Ready")
+
+
+def test_charm_active_with_org_only():
+    """
+    arrange: Only org is set (no repo, no runner-group).
+    act: Run config-changed.
+    assert: Unit status is Active.
+    """
+    ctx = Context(GarmConfiguratorCharm)
+    secret = _make_secret()
+    pk_secret = _make_private_key_secret()
+    config = _valid_config(secret, pk_secret)
+    del config["repo"]
+    config["org"] = "myorg"
+    state = State(config=config, secrets=[secret, pk_secret])
+    out = ctx.run(ctx.on.config_changed(), state)
+    assert out.unit_status == ops.ActiveStatus("Ready")

--- a/charms/garm-configurator/tests/unit/test_charm.py
+++ b/charms/garm-configurator/tests/unit/test_charm.py
@@ -236,6 +236,25 @@ def test_charm_blocked_negative_max_runner():
     assert out.unit_status == ops.BlockedStatus("max-runner must be non-negative")
 
 
+def test_charm_blocked_max_runner_less_than_min_idle_runner():
+    """
+    arrange: max-runner is less than min-idle-runner.
+    act: Run config-changed.
+    assert: Unit status is Blocked.
+    """
+    ctx = Context(GarmConfiguratorCharm)
+    secret = _make_secret()
+    pk_secret = _make_private_key_secret()
+    config = _valid_config(secret, pk_secret)
+    config["min-idle-runner"] = 5
+    config["max-runner"] = 3
+    state = State(config=config, secrets=[secret, pk_secret])
+    out = ctx.run(ctx.on.config_changed(), state)
+    assert out.unit_status == ops.BlockedStatus(
+        "max-runner must be greater than or equal to min-idle-runner"
+    )
+
+
 def test_charm_blocked_neither_repo_nor_org():
     """
     arrange: Neither repo nor org is set.

--- a/charms/garm-configurator/tests/unit/test_charm.py
+++ b/charms/garm-configurator/tests/unit/test_charm.py
@@ -260,7 +260,8 @@ def test_charm_active_with_org_and_runner_group():
     del config["repo"]
     config["org"] = "myorg"
     config["runner-group"] = "my-group"
-    state = State(config=config, secrets=[secret, pk_secret])
+    image_relation = Relation(endpoint="image", remote_units_data={0: {"id": "abc-image-uuid"}})
+    state = State(config=config, secrets=[secret, pk_secret], relations=[image_relation])
     out = ctx.run(ctx.on.config_changed(), state)
     assert out.unit_status == ops.ActiveStatus("Ready")
 
@@ -277,7 +278,8 @@ def test_charm_active_with_org_only():
     config = _valid_config(secret, pk_secret)
     del config["repo"]
     config["org"] = "myorg"
-    state = State(config=config, secrets=[secret, pk_secret])
+    image_relation = Relation(endpoint="image", remote_units_data={0: {"id": "abc-image-uuid"}})
+    state = State(config=config, secrets=[secret, pk_secret], relations=[image_relation])
     out = ctx.run(ctx.on.config_changed(), state)
     assert out.unit_status == ops.ActiveStatus("Ready")
 
@@ -314,7 +316,9 @@ def test_reconcile_writes_credentials_on_secret_changed():
     assert: The rotated password (latest revision) is pushed to the relation databag.
     """
     ctx = Context(GarmConfiguratorCharm)
-    secret = Secret(tracked_content={"value": "old-password"}, latest_content={"value": "new-password"})
+    secret = Secret(
+        tracked_content={"value": "old-password"}, latest_content={"value": "new-password"}
+    )
     pk_secret = _make_private_key_secret()
     image_relation = Relation(endpoint="image")
     state = State(

--- a/charms/garm-configurator/tests/unit/test_charm.py
+++ b/charms/garm-configurator/tests/unit/test_charm.py
@@ -59,33 +59,93 @@ _MISSING_CONFIG_SENTINEL = object()
 
 
 @pytest.mark.parametrize(
-    "config_key, override_value",
+    "config_mutations, expected_message",
     [
-        pytest.param("openstack-auth-url", _MISSING_CONFIG_SENTINEL, id="missing-auth-url"),
-        pytest.param("openstack-username", "", id="empty-username"),
-        pytest.param("openstack-password", _MISSING_CONFIG_SENTINEL, id="missing-password"),
-        pytest.param("openstack-network", "   ", id="whitespace-only-network"),
         pytest.param(
-            "github-app-client-id", _MISSING_CONFIG_SENTINEL, id="missing-github-app-client-id"
+            {"openstack-auth-url": _MISSING_CONFIG_SENTINEL},
+            "Missing required configuration: openstack-auth-url",
+            id="missing-auth-url",
         ),
         pytest.param(
-            "github-app-installation-id",
-            _MISSING_CONFIG_SENTINEL,
+            {"openstack-username": ""},
+            "Missing required configuration: openstack-username",
+            id="empty-username",
+        ),
+        pytest.param(
+            {"openstack-password": _MISSING_CONFIG_SENTINEL},
+            "Missing required configuration: openstack-password",
+            id="missing-password",
+        ),
+        pytest.param(
+            {"openstack-network": "   "},
+            "Missing required configuration: openstack-network",
+            id="whitespace-only-network",
+        ),
+        pytest.param(
+            {"github-app-client-id": _MISSING_CONFIG_SENTINEL},
+            "Missing required configuration: github-app-client-id",
+            id="missing-github-app-client-id",
+        ),
+        pytest.param(
+            {"github-app-installation-id": _MISSING_CONFIG_SENTINEL},
+            "Missing required configuration: github-app-installation-id",
             id="missing-github-app-installation-id",
         ),
         pytest.param(
-            "github-app-private-key",
-            _MISSING_CONFIG_SENTINEL,
+            {"github-app-private-key": _MISSING_CONFIG_SENTINEL},
+            "Missing required configuration: github-app-private-key",
             id="missing-github-app-private-key",
         ),
-        pytest.param("name", _MISSING_CONFIG_SENTINEL, id="missing-name"),
-        pytest.param("flavor", "", id="empty-flavor"),
-        pytest.param("os-arch", "   ", id="whitespace-only-os-arch"),
+        pytest.param(
+            {"name": _MISSING_CONFIG_SENTINEL},
+            "Missing required configuration: name",
+            id="missing-name",
+        ),
+        pytest.param(
+            {"flavor": ""},
+            "Missing required configuration: flavor",
+            id="empty-flavor",
+        ),
+        pytest.param(
+            {"os-arch": "   "},
+            "Missing required configuration: os-arch",
+            id="whitespace-only-os-arch",
+        ),
+        pytest.param(
+            {"openstack-auth-url": "ftp://invalid.example.com"},
+            "openstack-auth-url must start with http:// or https://",
+            id="invalid-auth-url",
+        ),
+        pytest.param(
+            {"min-idle-runner": -1},
+            "min-idle-runner must be non-negative",
+            id="negative-min-idle-runner",
+        ),
+        pytest.param(
+            {"max-runner": -5},
+            "max-runner must be non-negative",
+            id="negative-max-runner",
+        ),
+        pytest.param(
+            {"min-idle-runner": 5, "max-runner": 3},
+            "max-runner must be greater than or equal to min-idle-runner",
+            id="max-runner-less-than-min-idle-runner",
+        ),
+        pytest.param(
+            {"repo": _MISSING_CONFIG_SENTINEL},
+            "At least one of repo or org must be provided",
+            id="neither-repo-nor-org",
+        ),
+        pytest.param(
+            {"org": "myorg"},
+            "repo and org are mutually exclusive",
+            id="repo-and-org-both-set",
+        ),
     ],
 )
-def test_charm_blocked_missing_or_empty_config(config_key: str, override_value: object):
+def test_charm_blocked_invalid_config(config_mutations: dict, expected_message: str):
     """
-    arrange: A required config key is missing or empty/whitespace.
+    arrange: Config is invalid (missing, empty, or has an invalid value).
     act: Run config-changed.
     assert: Unit status is Blocked with the expected message.
     """
@@ -93,31 +153,14 @@ def test_charm_blocked_missing_or_empty_config(config_key: str, override_value: 
     secret = _make_secret()
     pk_secret = _make_private_key_secret()
     config = _valid_config(secret, pk_secret)
-    if override_value is _MISSING_CONFIG_SENTINEL:
-        del config[config_key]
-    else:
-        config[config_key] = override_value
+    for key, value in config_mutations.items():
+        if value is _MISSING_CONFIG_SENTINEL:
+            del config[key]
+        else:
+            config[key] = value
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus(f"Missing required configuration: {config_key}")
-
-
-def test_charm_blocked_invalid_auth_url():
-    """
-    arrange: openstack-auth-url does not start with http:// or https://.
-    act: Run config-changed.
-    assert: Unit status is Blocked.
-    """
-    ctx = Context(GarmConfiguratorCharm)
-    secret = _make_secret()
-    pk_secret = _make_private_key_secret()
-    config = _valid_config(secret, pk_secret)
-    config["openstack-auth-url"] = "ftp://invalid.example.com"
-    state = State(config=config, secrets=[secret, pk_secret])
-    out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus(
-        "openstack-auth-url must start with http:// or https://"
-    )
+    assert out.unit_status == ops.BlockedStatus(expected_message)
 
 
 def test_charm_blocked_password_secret_missing_value_key():
@@ -202,89 +245,6 @@ def test_charm_blocked_github_app_private_key_secret_not_found():
     assert out.unit_status == ops.BlockedStatus(
         "github-app-private-key secret is invalid or missing 'value' key"
     )
-
-
-def test_charm_blocked_negative_min_idle_runner():
-    """
-    arrange: min-idle-runner is negative.
-    act: Run config-changed.
-    assert: Unit status is Blocked.
-    """
-    ctx = Context(GarmConfiguratorCharm)
-    secret = _make_secret()
-    pk_secret = _make_private_key_secret()
-    config = _valid_config(secret, pk_secret)
-    config["min-idle-runner"] = -1
-    state = State(config=config, secrets=[secret, pk_secret])
-    out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("min-idle-runner must be non-negative")
-
-
-def test_charm_blocked_negative_max_runner():
-    """
-    arrange: max-runner is negative.
-    act: Run config-changed.
-    assert: Unit status is Blocked.
-    """
-    ctx = Context(GarmConfiguratorCharm)
-    secret = _make_secret()
-    pk_secret = _make_private_key_secret()
-    config = _valid_config(secret, pk_secret)
-    config["max-runner"] = -5
-    state = State(config=config, secrets=[secret, pk_secret])
-    out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("max-runner must be non-negative")
-
-
-def test_charm_blocked_max_runner_less_than_min_idle_runner():
-    """
-    arrange: max-runner is less than min-idle-runner.
-    act: Run config-changed.
-    assert: Unit status is Blocked.
-    """
-    ctx = Context(GarmConfiguratorCharm)
-    secret = _make_secret()
-    pk_secret = _make_private_key_secret()
-    config = _valid_config(secret, pk_secret)
-    config["min-idle-runner"] = 5
-    config["max-runner"] = 3
-    state = State(config=config, secrets=[secret, pk_secret])
-    out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus(
-        "max-runner must be greater than or equal to min-idle-runner"
-    )
-
-
-def test_charm_blocked_neither_repo_nor_org():
-    """
-    arrange: Neither repo nor org is set.
-    act: Run config-changed.
-    assert: Unit status is Blocked.
-    """
-    ctx = Context(GarmConfiguratorCharm)
-    secret = _make_secret()
-    pk_secret = _make_private_key_secret()
-    config = _valid_config(secret, pk_secret)
-    del config["repo"]
-    state = State(config=config, secrets=[secret, pk_secret])
-    out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("At least one of repo or org must be provided")
-
-
-def test_charm_blocked_repo_and_org_both_set():
-    """
-    arrange: Both repo and org are set.
-    act: Run config-changed.
-    assert: Unit status is Blocked.
-    """
-    ctx = Context(GarmConfiguratorCharm)
-    secret = _make_secret()
-    pk_secret = _make_private_key_secret()
-    config = _valid_config(secret, pk_secret)
-    config["org"] = "myorg"
-    state = State(config=config, secrets=[secret, pk_secret])
-    out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("repo and org are mutually exclusive")
 
 
 def test_charm_active_with_org_and_runner_group():

--- a/charms/garm-configurator/tests/unit/test_charm.py
+++ b/charms/garm-configurator/tests/unit/test_charm.py
@@ -249,9 +249,7 @@ def test_charm_blocked_neither_repo_nor_org():
     del config["repo"]
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus(
-        "At least one of repo or org must be provided"
-    )
+    assert out.unit_status == ops.BlockedStatus("At least one of repo or org must be provided")
 
 
 def test_charm_blocked_repo_and_org_both_set():

--- a/charms/tests/integration/test_garm_configurator.py
+++ b/charms/tests/integration/test_garm_configurator.py
@@ -71,6 +71,10 @@ def deploy_garm_configurator_app_fixture(
             "github-app-client-id": "12345",
             "github-app-installation-id": "67890",
             "github-app-private-key": private_key_secret_uri,
+            "name": "test-scaleset",
+            "flavor": "m1.large",
+            "os-arch": "amd64",
+            "repo": "myorg/myrepo",
         },
     )
     juju.wait(

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -80,3 +80,4 @@ retrigger(ing)?
 Diátaxis
 hostmetrics
 configurator
+scaleset

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-03
+
+- add GARM Scaleset configurations for the GARM configurator charm.
+
 ## 2026-06-02
 
 - add OpenStack and GitHub creds/configs for the GARM configurator charm.


### PR DESCRIPTION
#### What this PR does

Add the scaleset configurations for GARM configurator charm.

##### AI summary
This pull request adds comprehensive support for configuring GitHub runner scalesets in the `garm-configurator` charm. It introduces new configuration options for scaleset management, validates these options, and extends both the charm's logic and its tests to ensure robust handling of various configuration scenarios.

**Key changes:**

Configuration and validation for scalesets:
* Added new config options (`name`, `flavor`, `os-arch`, `min-idle-runner`, `max-runner`, `labels`, `repo`, `org`, `runner-group`, `pre-install-scripts`) to `charmcraft.yaml` for flexible scaleset configuration.
* Introduced constants for these new config keys in `charm_state.py` for maintainability.
* Implemented the `ScalesetConfig` class with validation logic, ensuring required fields are present, numeric fields are non-negative, and that `repo` and `org` are mutually exclusive but at least one is set.

Charm state and integration:
* Updated the `CharmState` class and its `from_charm` method to include and initialize the new `ScalesetConfig`. [[1]](diffhunk://#diff-fc3939787ec32183ec7936d2bfa75f7bd928f2449c3703ec04e398b6bbbb6f67R190-R315) [[2]](diffhunk://#diff-fc3939787ec32183ec7936d2bfa75f7bd928f2449c3703ec04e398b6bbbb6f67R332-R336)

Testing enhancements:
* Expanded unit and integration tests to cover new configuration options and validation logic, including cases for missing, empty, or invalid values, and correct handling of mutually exclusive options. [[1]](diffhunk://#diff-fbd0d6d9380ef3ff613bd989f062f4b3689760d107bd5f2fe2e3f564cb189459R34-R39) [[2]](diffhunk://#diff-fbd0d6d9380ef3ff613bd989f062f4b3689760d107bd5f2fe2e3f564cb189459R81-R83) [[3]](diffhunk://#diff-fbd0d6d9380ef3ff613bd989f062f4b3689760d107bd5f2fe2e3f564cb189459R205-R305) [[4]](diffhunk://#diff-b0e8735b9233e7c2083c48f85b2ed8ec4b2d3e5769e046baf6f93962fa4fe5fbR74-R77)

#### Why we need it

Needed to support the scaleset features of GARM charm.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [x] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run)
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR involves Rockcraft:** I updated the version

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

