### PR TITLE
ci: add garm charm publish to edge workflow

### DIFF
--- a/.github/workflows/publish_charms.yml
+++ b/.github/workflows/publish_charms.yml
@@ -16,9 +16,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        charm:
-        - planner
-        - webhook-gateway
+        include:
+        - charm: planner
+          path: charms/planner-operator
+          rockcraft: planner-rockcraft.yaml
+        - charm: webhook-gateway
+          path: charms/webhook-gateway-operator
+          rockcraft: webhook-gateway-rockcraft.yaml
+        - charm: garm
+          path: charms/garm
+          rockcraft: garm-rockcraft.yaml
     permissions:
       actions: read
       contents: write
@@ -30,9 +37,9 @@ jobs:
       run: sudo rm -rf /usr/local/lib/android
     - name: setup lxd
       uses: canonical/setup-lxd@v1
-    - name: rename ${{ matrix.charm }}-rockcraft.yaml
+    - name: rename ${{ matrix.rockcraft }}
       run: |
-        mv ${{ matrix.charm }}-rockcraft.yaml rockcraft.yaml
+        mv ${{ matrix.rockcraft }} rockcraft.yaml
     - name: build rock
       id: rockcraft
       run: |
@@ -48,7 +55,7 @@ jobs:
         rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:${{ steps.rockcraft.outputs.rock }} docker://localhost:5000/rock:latest
     - name: build charm
       id: charmcraft
-      working-directory: charms/${{ matrix.charm }}-operator/
+      working-directory: ${{ matrix.path }}/
       run: |
         sudo snap install --channel latest/stable --classic charmcraft
         charmcraft pack --verbosity trace
@@ -57,13 +64,13 @@ jobs:
         echo charmcraft pack:
         echo ${{ steps.charmcraft.outputs.charms }}
     - id: charm-name
-      working-directory: charms/${{ matrix.charm }}-operator/
+      working-directory: ${{ matrix.path }}/
       run: |
         echo charm-name=`yq -r .name charmcraft.yaml` >> $GITHUB_OUTPUT
     - run: |
         sudo apt update && sudo apt install python3-yaml -y
     - name: update upstream-source
-      working-directory: charms/${{ matrix.charm }}-operator/
+      working-directory: ${{ matrix.path }}/
       shell: python
       run: |
         import os
@@ -79,10 +86,10 @@ jobs:
         resources = charmcraft_yaml["resources"]
         resources[list(resources)[0]]["upstream-source"] = "localhost:5000/rock:latest"
         yaml.dump(charmcraft_yaml, open("charmcraft.yaml", "w"), sort_keys=False)
-    - working-directory: charms/${{ matrix.charm }}-operator/
+    - working-directory: ${{ matrix.path }}/
       run: |
         echo upload charm ${{ steps.charm-name.outputs.charm-name }}
-    - working-directory: charms/${{ matrix.charm }}-operator/
+    - working-directory: ${{ matrix.path }}/
       run: |
         cat charmcraft.yaml
     - if: github.event_name == 'push'
@@ -93,7 +100,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         built-charm-path: ${{ steps.charmcraft.outputs.charms }}
         tag-prefix: ${{ steps.charm-name.outputs.charm-name }}
-        charm-path: charms/${{ matrix.charm }}-operator
+        charm-path: ${{ matrix.path }}
 
   publish-garm-configurator:
     name: ${{ github.event_name == 'push' && '' || 'Test ' }}Publish Charm (garm-configurator)


### PR DESCRIPTION
## Summary

Add `publish-garm` job to `publish_charms.yml` that:
1. Builds the garm rock (`garm-rockcraft.yaml`)
2. Pushes rock to local registry
3. Builds the garm charm (`charms/garm/`)
4. Updates `upstream-source` in charmcraft.yaml
5. Publishes to Charmhub edge channel on push to main

Follows the same pattern as planner/webhook-gateway (rock + charm) but uses a separate job since the charm directory is `charms/garm/` (not `charms/garm-operator/`).

## Prerequisites

`charmcraft register garm` must be run to register the charm name on Charmhub before the first publish.