### PR TITLE
feat(garm): export Prometheus metrics without JWT auth

### DIFF
--- a/charms/garm/charmcraft.yaml
+++ b/charms/garm/charmcraft.yaml
@@ -16,8 +16,9 @@ description: |
   Deploys and manages GARM (GitHub Actions Runner Manager) using the
   12-factor app framework with PostgreSQL storage and an OpenStack runner provider.
 
-  GARM serves its API and Prometheus metrics on a single fixed port (8080); the
-  framework's app-port and metrics-port options are not used.
+  GARM serves its API and Prometheus metrics on a single fixed port (8080), and
+  its scrape target is declared in paas-config.yaml; the framework's app-port,
+  metrics-port and metrics-path options are not used.
 
 extensions:
   - go-framework

--- a/charms/garm/charmcraft.yaml
+++ b/charms/garm/charmcraft.yaml
@@ -25,13 +25,3 @@ requires:
     optional: false
     limit: 1
 
-config:
-  options:
-    garm-listen-address:
-      type: string
-      default: "0.0.0.0"
-      description: Address GARM API server listens on.
-    garm-listen-port:
-      type: int
-      default: 9997
-      description: Port GARM API server listens on.

--- a/charms/garm/charmcraft.yaml
+++ b/charms/garm/charmcraft.yaml
@@ -16,6 +16,9 @@ description: |
   Deploys and manages GARM (GitHub Actions Runner Manager) using the
   12-factor app framework with PostgreSQL storage and an OpenStack runner provider.
 
+  GARM serves its API and Prometheus metrics on a single fixed port (8080); the
+  framework's app-port and metrics-port options are not used.
+
 extensions:
   - go-framework
 

--- a/charms/garm/paas-config.yaml
+++ b/charms/garm/paas-config.yaml
@@ -1,0 +1,14 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Prometheus scrape configuration for GARM.
+#
+# GARM serves its API and /metrics on a single port (the framework app-port,
+# default 8080). The framework's default metrics-port scrape job is disabled in
+# the charm (see GarmCharm._workload_config), so this is the sole scrape target.
+prometheus:
+  scrape_configs:
+    - job_name: garm
+      metrics_path: /metrics
+      static_configs:
+        - targets: ["*:8080"]

--- a/charms/garm/paas-config.yaml
+++ b/charms/garm/paas-config.yaml
@@ -3,9 +3,9 @@
 
 # Prometheus scrape configuration for GARM.
 #
-# GARM serves its API and /metrics on a single port (the framework app-port,
-# default 8080). The framework's default metrics-port scrape job is disabled in
-# the charm (see GarmCharm._workload_config), so this is the sole scrape target.
+# GARM serves its API and /metrics on a single fixed port (8080); the charm pins
+# the workload port and disables the framework's default metrics-port scrape job
+# (see GarmCharm._workload_config), so this is the sole scrape target.
 prometheus:
   scrape_configs:
     - job_name: garm

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -4,6 +4,7 @@
 
 """GARM charm entrypoint."""
 
+import dataclasses
 import logging
 import secrets
 import string
@@ -12,6 +13,7 @@ import typing
 import ops
 import paas_charm.go
 import tomli_w
+from paas_charm.app import WorkloadConfig
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +122,17 @@ class GarmCharm(paas_charm.go.Charm):
         """Ensure secrets exist on first install."""
         self._ensure_secrets()
 
+    @property
+    def _workload_config(self) -> WorkloadConfig:
+        """Disable the framework's default metrics-port scrape job.
+
+        GARM serves /metrics on its single API port and the scrape target is
+        declared explicitly in paas-config.yaml. Setting metrics_target to None
+        stops paas-charm from also emitting a default job for metrics-port, which
+        would otherwise scrape /metrics a second time.
+        """
+        return dataclasses.replace(super()._workload_config, metrics_target=None)
+
     def restart(self, rerun_migrations: bool = False) -> None:
         """Write GARM config then restart the workload.
 
@@ -132,18 +145,6 @@ class GarmCharm(paas_charm.go.Charm):
         if not self.is_ready():
             return
         self._ensure_secrets()
-
-        # GARM serves its API and /metrics on a single port, so the framework's
-        # app-port and metrics-port must match; otherwise Prometheus would scrape
-        # a port GARM is not listening on.
-        app_port = int(self.config.get("app-port", 8080))
-        metrics_port = int(self.config.get("metrics-port", 8080))
-        if app_port != metrics_port:
-            self.unit.status = ops.BlockedStatus(
-                f"metrics-port ({metrics_port}) must equal app-port ({app_port}): "
-                "GARM does not support serving metrics on a different port"
-            )
-            return
 
         # Short-circuit if postgresql relation data is not yet available.
         # GARM cannot start without a database connection.

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -149,17 +149,26 @@ class GarmCharm(paas_charm.go.Charm):
             return
         self._ensure_secrets()
 
-        # app-port is injected by the go-framework extension but is unsupported:
-        # GARM always serves its API and metrics on GARM_PORT. Warn rather than
-        # block, and tolerate the option being absent (it may be removed from the
-        # framework in future).
-        configured_port = self.config.get("app-port")
-        if configured_port is not None and int(configured_port) != GARM_PORT:
-            logger.warning(
-                "app-port=%s is not supported; GARM always serves its API and metrics on port %d",
-                configured_port,
-                GARM_PORT,
-            )
+        # The go-framework extension injects app-port, metrics-port and
+        # metrics-path, but GARM supports none of them: it serves its API and
+        # metrics on a fixed port (GARM_PORT) and declares its Prometheus scrape
+        # target in paas-config.yaml. Warn rather than block when an operator sets
+        # any to a non-default value, tolerating their absence (the framework may
+        # drop them in future).
+        for option, default in (
+            ("app-port", GARM_PORT),
+            ("metrics-port", GARM_PORT),
+            ("metrics-path", "/metrics"),
+        ):
+            value = self.config.get(option)
+            if value is not None and str(value) != str(default):
+                logger.warning(
+                    "%s=%s is not supported and has no effect; GARM serves on port %d and "
+                    "declares its Prometheus scrape config in paas-config.yaml",
+                    option,
+                    value,
+                    GARM_PORT,
+                )
 
         # Short-circuit if postgresql relation data is not yet available.
         # GARM cannot start without a database connection.

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -140,8 +140,8 @@ class GarmCharm(paas_charm.go.Charm):
         metrics_port = int(self.config.get("metrics-port", 8080))
         if app_port != metrics_port:
             self.unit.status = ops.BlockedStatus(
-                f"app-port ({app_port}) and metrics-port ({metrics_port}) must be equal: "
-                "GARM serves its API and metrics on a single port"
+                f"metrics-port ({metrics_port}) must equal app-port ({app_port}): "
+                "GARM does not support serving metrics on a different port"
             )
             return
 

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -149,12 +149,12 @@ class GarmCharm(paas_charm.go.Charm):
             return
         self._ensure_secrets()
 
-        # The go-framework extension injects app-port, metrics-port and
-        # metrics-path, but GARM supports none of them: it serves its API and
-        # metrics on a fixed port (GARM_PORT) and declares its Prometheus scrape
-        # target in paas-config.yaml. Warn rather than block when an operator sets
-        # any to a non-default value, tolerating their absence (the framework may
-        # drop them in future).
+        # GARM serves its API and metrics on the same port (it has no separate
+        # metrics listener), so the go-framework's app-port/metrics-port/metrics-path
+        # settings don't apply and this charm doesn't use them: the port is fixed to
+        # GARM_PORT and the scrape target is declared in paas-config.yaml. Warn rather
+        # than block when an operator sets any to a non-default value, tolerating
+        # their absence (the framework may drop them in future).
         for option, default in (
             ("app-port", GARM_PORT),
             ("metrics-port", GARM_PORT),

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -133,6 +133,14 @@ class GarmCharm(paas_charm.go.Charm):
             return
         self._ensure_secrets()
 
+        port_error = _validate_ports(
+            int(self.config.get("app-port", 8080)),
+            int(self.config.get("metrics-port", 8080)),
+        )
+        if port_error:
+            self.unit.status = ops.BlockedStatus(port_error)
+            return
+
         # Short-circuit if postgresql relation data is not yet available.
         # GARM cannot start without a database connection.
         if not self._get_postgresql_config():
@@ -250,6 +258,28 @@ class GarmCharm(paas_charm.go.Charm):
             postgresql_config=postgresql_config,
         )
         container.push(GARM_CONFIG_PATH, toml_content, make_dirs=True)
+
+
+def _validate_ports(app_port: int, metrics_port: int) -> str | None:
+    """Return a blocked-status message if the port config is inconsistent, else None.
+
+    GARM serves its API and /metrics on a single port, so the framework's
+    app-port and metrics-port must match; otherwise Prometheus would scrape a
+    port GARM is not listening on.
+
+    Args:
+        app_port: The port GARM's API server (and /metrics) listens on.
+        metrics_port: The port the framework configures Prometheus to scrape.
+
+    Returns:
+        A human-readable blocked-status message when the ports differ, else None.
+    """
+    if app_port != metrics_port:
+        return (
+            f"app-port ({app_port}) and metrics-port ({metrics_port}) must be equal: "
+            "GARM serves its API and metrics on a single port"
+        )
+    return None
 
 
 if __name__ == "__main__":

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -23,6 +23,7 @@ CONTAINER_NAME: typing.Final[str] = "app"
 PEBBLE_SERVICE_NAME: typing.Final[str] = "app"
 GARM_BINARY: typing.Final[str] = "/usr/local/bin/garm"
 OPENSTACK_PROVIDER_BINARY: typing.Final[str] = "/usr/local/bin/garm-provider-openstack"
+GARM_PORT: typing.Final[int] = 8080
 
 _DB_PASSPHRASE_LENGTH: typing.Final[int] = 32
 
@@ -124,14 +125,16 @@ class GarmCharm(paas_charm.go.Charm):
 
     @property
     def _workload_config(self) -> WorkloadConfig:
-        """Disable the framework's default metrics-port scrape job.
+        """Pin GARM to a fixed port and disable the default metrics scrape job.
 
-        GARM serves /metrics on its single API port and the scrape target is
-        declared explicitly in paas-config.yaml. Setting metrics_target to None
-        stops paas-charm from also emitting a default job for metrics-port, which
-        would otherwise scrape /metrics a second time.
+        GARM serves its API and /metrics on a single fixed port (GARM_PORT);
+        the framework's app-port is unsupported, so we force the workload port
+        (used for ingress, opened ports, and the service URL) to GARM_PORT
+        rather than reading app-port. The scrape target is declared in
+        paas-config.yaml, so metrics_target is set to None to suppress the
+        framework's default metrics-port scrape job.
         """
-        return dataclasses.replace(super()._workload_config, metrics_target=None)
+        return dataclasses.replace(super()._workload_config, port=GARM_PORT, metrics_target=None)
 
     def restart(self, rerun_migrations: bool = False) -> None:
         """Write GARM config then restart the workload.
@@ -145,6 +148,18 @@ class GarmCharm(paas_charm.go.Charm):
         if not self.is_ready():
             return
         self._ensure_secrets()
+
+        # app-port is injected by the go-framework extension but is unsupported:
+        # GARM always serves its API and metrics on GARM_PORT. Warn rather than
+        # block, and tolerate the option being absent (it may be removed from the
+        # framework in future).
+        configured_port = self.config.get("app-port")
+        if configured_port is not None and int(configured_port) != GARM_PORT:
+            logger.warning(
+                "app-port=%s is not supported; GARM always serves its API and metrics on port %d",
+                configured_port,
+                GARM_PORT,
+            )
 
         # Short-circuit if postgresql relation data is not yet available.
         # GARM cannot start without a database connection.
@@ -257,7 +272,7 @@ class GarmCharm(paas_charm.go.Charm):
             postgresql_config["port"],
         )
         toml_content = render_garm_toml(
-            listen_port=int(self.config.get("app-port", 8080)),
+            listen_port=GARM_PORT,
             jwt_secret=secrets["jwt-secret"],
             db_passphrase=secrets["db-passphrase"],
             postgresql_config=postgresql_config,

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -40,7 +40,6 @@ def _generate_passphrase(length: int = _DB_PASSPHRASE_LENGTH) -> str:
 
 def render_garm_toml(
     *,
-    listen_address: str,
     listen_port: int,
     jwt_secret: str,
     db_passphrase: str,
@@ -49,7 +48,6 @@ def render_garm_toml(
     """Render GARM's TOML configuration file content.
 
     Args:
-        listen_address: IP address for the GARM API server to bind on.
         listen_port: Port for the GARM API server.
         jwt_secret: Secret string used to sign GARM JWT tokens.
         db_passphrase: 32-character passphrase for AES-256 encryption of secrets in the DB.
@@ -66,7 +64,7 @@ def render_garm_toml(
             "postgresql": postgresql_config,
         },
         "apiserver": {
-            "bind": listen_address,
+            "bind": "0.0.0.0",
             "port": listen_port,
             "use_tls": False,
         },
@@ -246,8 +244,7 @@ class GarmCharm(paas_charm.go.Charm):
             postgresql_config["port"],
         )
         toml_content = render_garm_toml(
-            listen_address=str(self.config.get("garm-listen-address", "0.0.0.0")),
-            listen_port=int(self.config.get("garm-listen-port", 9997)),
+            listen_port=int(self.config.get("app-port", 8080)),
             jwt_secret=secrets["jwt-secret"],
             db_passphrase=secrets["db-passphrase"],
             postgresql_config=postgresql_config,

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -133,12 +133,16 @@ class GarmCharm(paas_charm.go.Charm):
             return
         self._ensure_secrets()
 
-        port_error = _validate_ports(
-            int(self.config.get("app-port", 8080)),
-            int(self.config.get("metrics-port", 8080)),
-        )
-        if port_error:
-            self.unit.status = ops.BlockedStatus(port_error)
+        # GARM serves its API and /metrics on a single port, so the framework's
+        # app-port and metrics-port must match; otherwise Prometheus would scrape
+        # a port GARM is not listening on.
+        app_port = int(self.config.get("app-port", 8080))
+        metrics_port = int(self.config.get("metrics-port", 8080))
+        if app_port != metrics_port:
+            self.unit.status = ops.BlockedStatus(
+                f"app-port ({app_port}) and metrics-port ({metrics_port}) must be equal: "
+                "GARM serves its API and metrics on a single port"
+            )
             return
 
         # Short-circuit if postgresql relation data is not yet available.
@@ -258,28 +262,6 @@ class GarmCharm(paas_charm.go.Charm):
             postgresql_config=postgresql_config,
         )
         container.push(GARM_CONFIG_PATH, toml_content, make_dirs=True)
-
-
-def _validate_ports(app_port: int, metrics_port: int) -> str | None:
-    """Return a blocked-status message if the port config is inconsistent, else None.
-
-    GARM serves its API and /metrics on a single port, so the framework's
-    app-port and metrics-port must match; otherwise Prometheus would scrape a
-    port GARM is not listening on.
-
-    Args:
-        app_port: The port GARM's API server (and /metrics) listens on.
-        metrics_port: The port the framework configures Prometheus to scrape.
-
-    Returns:
-        A human-readable blocked-status message when the ports differ, else None.
-    """
-    if app_port != metrics_port:
-        return (
-            f"app-port ({app_port}) and metrics-port ({metrics_port}) must be equal: "
-            "GARM serves its API and metrics on a single port"
-        )
-    return None
 
 
 if __name__ == "__main__":

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -149,12 +149,14 @@ class GarmCharm(paas_charm.go.Charm):
             return
         self._ensure_secrets()
 
-        # GARM serves its API and metrics on the same port (it has no separate
-        # metrics listener), so the go-framework's app-port/metrics-port/metrics-path
-        # settings don't apply and this charm doesn't use them: the port is fixed to
-        # GARM_PORT and the scrape target is declared in paas-config.yaml. Warn rather
-        # than block when an operator sets any to a non-default value, tolerating
-        # their absence (the framework may drop them in future).
+        # GARM serves its API and metrics on the same fixed port (GARM_PORT) — it has
+        # no separate metrics listener — and declares its scrape target in
+        # paas-config.yaml, so the go-framework's app-port/metrics-port/metrics-path
+        # settings don't apply. _workload_config also pins the workload port to
+        # GARM_PORT, so app-port has no effect on ingress, the opened ports, or the
+        # service URL (they can't drift from GARM's actual port). Warn rather than
+        # block when an operator sets any to a non-default value, tolerating their
+        # absence (the framework may drop them in future).
         for option, default in (
             ("app-port", GARM_PORT),
             ("metrics-port", GARM_PORT),

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     import tomli as tomllib  # type: ignore[no-redef]
 
-from charm import _generate_garm_secrets, render_garm_toml
+from charm import _generate_garm_secrets, _validate_ports, render_garm_toml
 
 _DEFAULT_PG_CONFIG = {
     "username": "u",
@@ -133,3 +133,18 @@ def test_generate_garm_secrets_produces_unique_values():
     second = _generate_garm_secrets()
     assert first["jwt-secret"] != second["jwt-secret"]
     assert first["db-passphrase"] != second["db-passphrase"]
+
+
+def test_validate_ports_equal_returns_none():
+    """Matching ports return None (no error)."""
+    assert _validate_ports(8080, 8080) is None
+    assert _validate_ports(9000, 9000) is None
+
+
+def test_validate_ports_mismatch_returns_message():
+    """Mismatched ports return a string mentioning both port numbers."""
+    result = _validate_ports(8080, 9000)
+    assert isinstance(result, str)
+    assert result
+    assert "8080" in result
+    assert "9000" in result

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     import tomli as tomllib  # type: ignore[no-redef]
 
-from charm import _generate_garm_secrets, _validate_ports, render_garm_toml
+from charm import _generate_garm_secrets, render_garm_toml
 
 _DEFAULT_PG_CONFIG = {
     "username": "u",
@@ -133,18 +133,3 @@ def test_generate_garm_secrets_produces_unique_values():
     second = _generate_garm_secrets()
     assert first["jwt-secret"] != second["jwt-secret"]
     assert first["db-passphrase"] != second["db-passphrase"]
-
-
-def test_validate_ports_equal_returns_none():
-    """Matching ports return None (no error)."""
-    assert _validate_ports(8080, 8080) is None
-    assert _validate_ports(9000, 9000) is None
-
-
-def test_validate_ports_mismatch_returns_message():
-    """Mismatched ports return a string mentioning both port numbers."""
-    result = _validate_ports(8080, 9000)
-    assert isinstance(result, str)
-    assert result
-    assert "8080" in result
-    assert "9000" in result

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -27,7 +27,7 @@ _DEFAULT_PG_CONFIG = {
 def _render(**overrides) -> dict:
     """Helper: render TOML with defaults, return parsed dict."""
     kwargs = {
-        "listen_port": 9997,
+        "listen_port": 8080,
         "jwt_secret": "test-secret",
         "db_passphrase": "a" * 32,
         "postgresql_config": _DEFAULT_PG_CONFIG,

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -27,7 +27,6 @@ _DEFAULT_PG_CONFIG = {
 def _render(**overrides) -> dict:
     """Helper: render TOML with defaults, return parsed dict."""
     kwargs = {
-        "listen_address": "0.0.0.0",
         "listen_port": 9997,
         "jwt_secret": "test-secret",
         "db_passphrase": "a" * 32,
@@ -79,7 +78,7 @@ def test_render_garm_toml_sslmode_propagated(sslmode: str):
 @pytest.mark.parametrize(
     "section,key,value,kwargs",
     [
-        ("apiserver", "bind", "127.0.0.1", {"listen_address": "127.0.0.1"}),
+        ("apiserver", "bind", "0.0.0.0", {}),
         ("apiserver", "port", 8080, {"listen_port": 8080}),
         ("apiserver", "use_tls", False, {}),
         ("jwt_auth", "secret", "mysecret", {"jwt_secret": "mysecret"}),

--- a/charms/tests/integration/test_garm.py
+++ b/charms/tests/integration/test_garm.py
@@ -25,7 +25,7 @@ GARM_BINARY = "/usr/local/bin/garm"
 GARM_PROVIDER_BINARY = "/usr/local/bin/garm-provider-openstack"
 GARM_CONFIG_PATH = "/etc/garm/config.toml"
 GARM_SECRETS_LABEL = "garm-secrets"
-GARM_API_PORT = 9997
+GARM_API_PORT = 8080
 PEBBLE_PREFIX = "PEBBLE_SOCKET=/charm/containers/app/pebble.socket /charm/bin/pebble"
 
 # Generated once per session so all test functions that call _garm_first_run use
@@ -381,3 +381,56 @@ def test_garm_juju_secret_has_expected_keys(
     assert (
         "db-passphrase" in content
     ), f"Expected 'db-passphrase' key in {GARM_SECRETS_LABEL}, got keys: {list(content)}"
+
+
+def test_garm_metrics_endpoint_no_auth(
+    juju: jubilant.Juju,
+    garm_app: str,
+):
+    """
+    arrange: The GARM charm is deployed, active, and connected to postgresql.
+    act: GET /metrics with no Authorization header.
+    assert: The endpoint responds 200 (JWT auth disabled) and exposes GARM metrics.
+    """
+    address = _get_garm_address(juju, garm_app)
+    metrics_url = f"http://{address}:{GARM_API_PORT}/metrics"
+    logger.info("Scraping GARM metrics (no auth) at %s", metrics_url)
+
+    # garm_health is the reliable signal that GARM's own metrics (not just the Go
+    # runtime metrics) are exported: it is populated by an immediate collection at
+    # startup and refreshed every tick. Retry briefly to absorb that startup
+    # window. Other metric names are documented in GARM's monitoring spec.
+    class _MetricsNotReady(Exception):
+        pass
+
+    @retry(
+        retry=retry_if_exception_type(
+            (requests.exceptions.ConnectionError, _MetricsNotReady)
+        ),
+        wait=wait_exponential(multiplier=1, min=1, max=30),
+        stop=stop_after_attempt(10),
+        reraise=True,
+    )
+    def _scrape() -> requests.Response:
+        # No Authorization header: a 200 proves JWT auth is disabled on /metrics.
+        response = requests.get(metrics_url, timeout=30)
+        # A 5xx may occur briefly while GARM is still warming up, so retry it. A
+        # 4xx (e.g. 401/403 if auth were required, 404 for a wrong path) is a real
+        # regression and must surface immediately rather than being masked as a
+        # metrics-warm-up timeout.
+        if response.status_code >= 500:
+            raise _MetricsNotReady()
+        assert response.status_code == requests.codes.ok, (
+            f"Expected 200 without a JWT token, got {response.status_code}: "
+            f"{response.text[:200]}"
+        )
+        if "garm_health" not in response.text:
+            raise _MetricsNotReady()
+        return response
+
+    resp = _scrape()
+    # _scrape only returns once it sees a 200 response containing garm_health.
+    assert "garm_health" in resp.text, (
+        "Expected the garm_health metric in the /metrics response; "
+        f"got first 500 chars: {resp.text[:500]}"
+    )

--- a/charms/tests/integration/test_garm.py
+++ b/charms/tests/integration/test_garm.py
@@ -145,6 +145,47 @@ def _garm_first_run(address: str) -> str:
     return token
 
 
+class _MetricsNotReady(Exception):
+    """Raised while GARM's /metrics is still warming up (retryable)."""
+
+
+@retry(
+    retry=retry_if_exception_type((requests.exceptions.ConnectionError, _MetricsNotReady)),
+    wait=wait_exponential(multiplier=1, min=1, max=30),
+    stop=stop_after_attempt(10),
+    reraise=True,
+)
+def _scrape_metrics_until_ready(metrics_url: str) -> requests.Response:
+    """Scrape GARM's /metrics (no auth) and retry until the metrics are populated.
+
+    garm_health is the reliable signal that GARM's own metrics (not just the Go
+    runtime metrics) are exported: it is populated by an immediate collection at
+    startup and refreshed every tick, so retry briefly to absorb that startup
+    window. Other metric names are documented in GARM's monitoring spec.
+
+    Args:
+        metrics_url: Full URL of GARM's /metrics endpoint.
+
+    Returns:
+        The successful (HTTP 200) response, which contains garm_health.
+    """
+    # No Authorization header: a 200 proves JWT auth is disabled on /metrics.
+    response = requests.get(metrics_url, timeout=30)
+    # A 5xx may occur briefly while GARM is still warming up, so retry it. A 4xx
+    # (e.g. 401/403 if auth were required, 404 for a wrong path) is a real
+    # regression and must surface immediately rather than being masked as a
+    # metrics-warm-up timeout.
+    if response.status_code >= 500:
+        raise _MetricsNotReady()
+    assert response.status_code == requests.codes.ok, (
+        f"Expected 200 without a JWT token, got {response.status_code}: "
+        f"{response.text[:200]}"
+    )
+    if "garm_health" not in response.text:
+        raise _MetricsNotReady()
+    return response
+
+
 def test_garm_blocks_without_postgresql(
     juju: jubilant.Juju,
     garm_app_deployed: str,
@@ -396,40 +437,8 @@ def test_garm_metrics_endpoint_no_auth(
     metrics_url = f"http://{address}:{GARM_API_PORT}/metrics"
     logger.info("Scraping GARM metrics (no auth) at %s", metrics_url)
 
-    # garm_health is the reliable signal that GARM's own metrics (not just the Go
-    # runtime metrics) are exported: it is populated by an immediate collection at
-    # startup and refreshed every tick. Retry briefly to absorb that startup
-    # window. Other metric names are documented in GARM's monitoring spec.
-    class _MetricsNotReady(Exception):
-        pass
-
-    @retry(
-        retry=retry_if_exception_type(
-            (requests.exceptions.ConnectionError, _MetricsNotReady)
-        ),
-        wait=wait_exponential(multiplier=1, min=1, max=30),
-        stop=stop_after_attempt(10),
-        reraise=True,
-    )
-    def _scrape() -> requests.Response:
-        # No Authorization header: a 200 proves JWT auth is disabled on /metrics.
-        response = requests.get(metrics_url, timeout=30)
-        # A 5xx may occur briefly while GARM is still warming up, so retry it. A
-        # 4xx (e.g. 401/403 if auth were required, 404 for a wrong path) is a real
-        # regression and must surface immediately rather than being masked as a
-        # metrics-warm-up timeout.
-        if response.status_code >= 500:
-            raise _MetricsNotReady()
-        assert response.status_code == requests.codes.ok, (
-            f"Expected 200 without a JWT token, got {response.status_code}: "
-            f"{response.text[:200]}"
-        )
-        if "garm_health" not in response.text:
-            raise _MetricsNotReady()
-        return response
-
-    resp = _scrape()
-    # _scrape only returns once it sees a 200 response containing garm_health.
+    resp = _scrape_metrics_until_ready(metrics_url)
+    # _scrape_metrics_until_ready only returns on a 200 response containing garm_health.
     assert "garm_health" in resp.text, (
         "Expected the garm_health metric in the /metrics response; "
         f"got first 500 chars: {resp.text[:500]}"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-15
+
+- export GARM Prometheus metrics via the `metrics-endpoint` integration, with JWT authentication disabled on the `/metrics` endpoint.
+
 ## 2026-06-08
 
 - reorder the template variables in the GitHub runner VM hostmetrics dashboard.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-06-15
 
-- export GARM Prometheus metrics via the `metrics-endpoint` integration, with JWT authentication disabled on the `/metrics` endpoint. GARM serves its API and metrics on a single fixed port (8080); the framework's `app-port`/`metrics-port` options are not used.
+- export GARM Prometheus metrics via the `metrics-endpoint` integration, with JWT authentication disabled on the `/metrics` endpoint. GARM serves its API and metrics on a single fixed port (8080); the framework's `app-port`/`metrics-port`/`metrics-path` options are not used.
 
 ## 2026-06-08
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-06-15
 
-- export GARM Prometheus metrics via the `metrics-endpoint` integration, with JWT authentication disabled on the `/metrics` endpoint.
+- export GARM Prometheus metrics via the `metrics-endpoint` integration, with JWT authentication disabled on the `/metrics` endpoint. GARM serves its API and metrics on a single fixed port (8080); the framework's `app-port`/`metrics-port` options are not used.
 
 ## 2026-06-08
 


### PR DESCRIPTION
#### What this PR does

Exports GARM's Prometheus metrics via the `metrics-endpoint` integration, without requiring a JWT token on `/metrics` (GARM already serves `/metrics` with auth disabled).

GARM serves its API **and** metrics on a single fixed port (8080) — it has no separate metrics listener. The Prometheus scrape target is declared via `paas-config.yaml` (`prometheus.scrape_configs`), per the paas-charm maintainer's guidance. The framework's default `metrics-port` scrape job is disabled (`GarmCharm._workload_config` sets `metrics_target=None`) so `/metrics` is scraped exactly once.

Because GARM uses a single fixed port, the framework's `app-port`, `metrics-port` and `metrics-path` config options don't apply and are not used: the charm pins the workload port to 8080, logs a warning if any of them is set to a non-default value, and notes this in the charm description. The earlier custom `garm-listen-port` / `garm-listen-address` options were removed. Unit and integration tests added.

#### Why we need it

So platform operators can observe runner and job metrics without JWT authentication on the metrics endpoint.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run)
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR involves Rockcraft:** I updated the version
