### PR TITLE
docs(agents): add AGENTS.md guidance and citation check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,8 @@
 - [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
 - [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
 - [ ] **If this PR involves Rockcraft:** I updated the version
+- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md`
+- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked whether the `AGENTS.md` "12-factor divergences" guidance still matches the upstream copilot-collections guidance
 
 <!--  
 You can adjust the checklist to match the project.

--- a/.github/workflows/agents_md_check.yaml
+++ b/.github/workflows/agents_md_check.yaml
@@ -1,0 +1,28 @@
+name: AGENTS.md Citation Check
+on:
+  pull_request:
+    paths:
+      - '**/AGENTS.md'
+      - 'charms/**'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'scripts/check_agents_md.py'
+      - 'tox.ini'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Validate AGENTS.md citations
+        run: python3 scripts/check_agents_md.py

--- a/.github/workflows/agents_md_check.yaml
+++ b/.github/workflows/agents_md_check.yaml
@@ -20,7 +20,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.3
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ guidance in `.github/instructions/` and the human-facing `CONTRIBUTING.md`.
 | `charms/` | Four Juju charms (see below) plus shared integration tests in `charms/tests/integration/`. |
 | `cmd/` | Go application entry points: `planner`, `webhook-gateway`. |
 | `internal/` | Shared Go packages (`database`, `github`, `planner`, `queue`, `server`, `telemetry`, `webhook`, …) — the application logic the paas charms package and deploy. |
-| `bundles`, `images` | Juju bundles and rock/image definitions. |
+| `*-rockcraft.yaml`, `build-*-rock.sh` (repo root) | Rock/image build definitions and their build scripts. |
 | `docs/` | Diátaxis-structured docs (Read the Docs). ADRs in `docs/adr/`. |
 | `actions/`, `runner_grafana_dashboards/` | A GitHub Action and runner-host dashboards. |
 | `parts`, `prime`, `stage`, `**/lib/charms/**` | **Generated or vendored — do not edit.** `lib/charms/**` is auto-updated; see `.github/instructions/charms-lib-updates.instructions.md`. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,10 @@ charms — there are four charms, not two).
 
 ## Build & test
 
-- `tox -e lint`, `tox -e format`, `tox -e static` — Python lint/format/type checks (ruff, black, mypy, pylint, bandit).
-- `tox -e <charm>-integration` — per-charm integration tests (`garm`, `webhook-gateway`, `planner`, `garm-configurator`), or `tox -e charms-integration` for all. Requires a live Juju model (jubilant + pytest-operator).
-- `go test ./...` — Go unit tests.
+- **Per-charm Python checks** — from the charm directory, `tox -c tox.toml` (envs `fmt`, `lint`, `complexity`, `static`, `unit`, `coverage-report`; ruff, codespell, pyright, pytest+coverage). CI runs these per charm via `tox -c tox.toml`.
+- **Integration tests** (root `tox.ini`) — `tox -e <charm>-integration` (`garm`, `webhook-gateway`, `planner`, `garm-configurator`) or `tox -e charms-integration` for all. Requires a live Juju model (jubilant + pytest-operator).
+- **`actions/` Python** — `tox -e actions-lint`, `tox -e actions-static`, `tox -e actions-unit`.
+- **Go** — `go test ./...`.
 - `charmcraft pack` — build a charm (run from the charm dir; not wired into tox).
 - Gates from `CONTRIBUTING.md`: **≥ 85% coverage** on internal packages, **cyclomatic complexity < 10** per function.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md
+
+Guidance for AI agents working in this monorepo. Keep changes surgical and idiomatic to
+the surrounding code. This file complements — and does not restate — the Copilot-specific
+guidance in `.github/instructions/` and the human-facing `CONTRIBUTING.md`.
+
+## Repository map
+
+| Path | Contents |
+| --- | --- |
+| `charms/` | Four Juju charms (see below) plus shared integration tests in `charms/tests/integration/`. |
+| `cmd/` | Go application entry points: `planner`, `webhook-gateway`. |
+| `internal/` | Shared Go packages (`database`, `github`, `planner`, `queue`, `server`, `telemetry`, `webhook`, …) — the application logic the paas charms package and deploy. |
+| `bundles/`, `images/` | Juju bundles and rock/image definitions. |
+| `docs/` | Diátaxis-structured docs (Read the Docs). ADRs in `docs/adr/`. |
+| `actions/`, `runner_grafana_dashboards/` | A GitHub Action and runner-host dashboards. |
+| `parts/`, `prime/`, `stage/`, `**/lib/charms/**` | **Generated or vendored — do not edit.** `lib/charms/**` is auto-updated; see `.github/instructions/charms-lib-updates.instructions.md`. |
+
+The Go layout follows the [community Go project layout](https://github.com/golang-standards/project-layout).
+`README.md` has the canonical layout (note: it predates the `garm` and `garm-configurator`
+charms — there are four charms, not two).
+
+### Charms
+
+| Charm | Base | Role |
+| --- | --- | --- |
+| `garm` | `paas_charm.go.Charm` | GARM (GitHub Actions Runner Manager) — 12-factor, PostgreSQL, OpenStack provider. |
+| `planner-operator` | `paas_charm.go.Charm` | Runner planner API — 12-factor Go app. |
+| `webhook-gateway-operator` | `paas_charm.go.Charm` | GitHub webhook receiver/forwarder — 12-factor Go app. |
+| `garm-configurator` | `ops.CharmBase` | Config broker for GARM scalesets. The **only** direct-`ops` charm. |
+
+## Build & test
+
+- `tox -e lint`, `tox -e format`, `tox -e static` — Python lint/format/type checks (ruff, black, mypy, pylint, bandit).
+- `tox -e <charm>-integration` — per-charm integration tests (`garm`, `webhook-gateway`, `planner`, `garm-configurator`), or `tox -e charms-integration` for all. Requires a live Juju model (jubilant + pytest-operator).
+- `go test ./...` — Go unit tests.
+- `charmcraft pack` — build a charm (run from the charm dir; not wired into tox).
+- Gates from `CONTRIBUTING.md`: **≥ 85% coverage** on internal packages, **cyclomatic complexity < 10** per function.
+
+## Charm conventions
+
+These are **K8s 12-factor charms** on the `go-framework` charmcraft extension: a thin Python
+charm layer wraps a Go workload (`CONTRIBUTING.md` §"12 factor"; each `charmcraft.yaml`).
+`garm-configurator` is the exception — a plain `ops` charm.
+
+### Holistic state handling — but don't add a second reconcile
+
+Charm logic should read full current state, act idempotently, and set unit status once.
+
+- **`paas_charm` charms (`garm`, `planner-operator`, `webhook-gateway-operator`)**: the base
+  class **already runs the holistic flow** (`PaasCharm.restart()`). Do **not** add a
+  `_reconcile` method. To inject behaviour, **override a framework hook** and call
+  `super()` — e.g. `restart()` (`garm`: write config + first-run; `planner-operator`: sync
+  relation endpoints) or `_create_app()` (`planner-operator`/`webhook-gateway-operator`:
+  inject OTel env). Gate on readiness with an early return (`if not self.is_ready(): return`),
+  not `event.defer()`.
+- **`garm-configurator`**: a single `_reconcile` that every event observes is the correct
+  pattern here (`GarmConfiguratorCharm._reconcile`): build state via
+  `CharmState.from_charm(self)`, write relation data, set status once at the end.
+
+### Ops / Juju lifecycle idioms agents get wrong
+
+- **Secrets — owner vs observer** (a common mistake): `refresh=True` is an *observer* concept —
+  it advances the unit's *tracked* revision to the latest. Use it only when **consuming a
+  secret you don't own** (an operator-supplied config secret, or one granted over a relation),
+  especially in `secret-changed` handlers, so you read the new revision instead of the stale
+  tracked one — e.g. the `*.from_charm` resolvers in `charms/garm-configurator/src/charm_state.py`.
+  When you **own** the secret (created via `add_secret`), plain `get_content()` already returns
+  the latest revision (and `set_content()` invalidates the cache), so `refresh=True` is
+  unnecessary — e.g. `garm`'s `_get_secrets` / `_get_admin_credentials`. Use `peek_content()`
+  to read the latest revision without changing tracking. The leader creates labelled secrets so
+  other units can fetch them by `label`.
+- **Relation data carries the secret id/URI, never the content**: `add_secret(..., label=...)`
+  → `secret.grant(relation)` → `relation.data[self.app]["token"] = str(secret.id)`
+  (`planner-operator`'s `_create_relation_credentials`).
+- Prefer **readiness-gating** (`is_ready()` early-return) over `event.defer()`.
+- Relation databags are **string-only** — serialise (e.g. `json.dumps`) structured values.
+
+### Testing
+
+- New unit tests use **Scenario** (`scenario.Context` / `State` / `Relation` / `Secret`),
+  not `Harness` — see `charms/garm-configurator/tests/unit/`.
+- Integration tests live in the shared `charms/tests/integration/`.
+
+## 12-factor divergences from the canonical charm-engineer guidance
+
+We borrow from the canonical
+[`charm-engineer.agent.md`](https://github.com/canonical/copilot-collections/blob/main/groups/platform-engineering/agents/charm-engineer.agent.md),
+but some of its rules assume a hand-written `ops` charm and do **not** apply to our paas charms:
+
+- **No second `_reconcile`** — the `paas_charm` base class reconciles (see above).
+- **No hand-authored `workload.py` / Pebble layer** — the `go-framework` extension owns the
+  workload; touch Pebble only inside a `restart()` override when strictly necessary.
+- **`state.py` Pydantic abstraction is optional** — only `garm-configurator` has a real
+  `CharmState`; don't force it onto paas charms.
+
+Still applicable: holistic state handling, idempotent `install`, explicit port handling, small
+`try/except` blocks scoped to custom exceptions, no Canonical-internal references in charm
+code, and **avoid `level=alive` health checks** in `rockcraft.yaml`.
+
+## Go code (`cmd/`, `internal/`)
+
+- Idiomatic Go; standard library first, third-party only when it's the established choice.
+- Table-driven tests; keep functions under the complexity gate; meet the coverage gate.
+- `internal/` is the workload that `planner-operator` and `webhook-gateway-operator` deploy —
+  changes here ripple into those charms.
+
+## Existing guidance (read, don't duplicate)
+
+- `.github/instructions/` — Copilot-specific: charm-library-update review protocol, code
+  commenting style, documentation rules. These are **auto-synced** from upstream
+  `canonical/copilot-collections` (pinned in `.copilot-collections.yaml`) by the weekly
+  `copilot-collections-update.yml` workflow.
+- `CONTRIBUTING.md` — dev workflow, coverage/complexity gates, the 12-factor reference.
+
+### Keeping this file honest
+
+- **Stays in sync with the code** via `scripts/check_agents_md.py` (run in CI by
+  `agents_md_check.yaml`): it fails if a cited path, private method, or `tox -e` env no longer
+  exists. Cite code by **symbol name**, not line number, so references survive refactors.
+- **Stays in sync with copilot-collections**: this file is a hand-curated *adaptation* of the
+  upstream guidance (it deliberately diverges for 12-factor — see above), so it can't be
+  auto-generated. When the weekly bump PR changes `.copilot-collections.yaml` or
+  `.github/instructions/`, re-read the "12-factor divergences" section above (the PR-template
+  checklist prompts this).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,10 +108,12 @@ code, and **avoid `level=alive` health checks** in `rockcraft.yaml`.
 
 ## Existing guidance (read, don't duplicate)
 
-- `.github/instructions/` — Copilot-specific: charm-library-update review protocol, code
-  commenting style, documentation rules. These are **auto-synced** from upstream
-  `canonical/copilot-collections` (pinned in `.copilot-collections.yaml`) by the weekly
-  `copilot-collections-update.yml` workflow.
+- `.github/instructions/` — guidance in GitHub Copilot's custom-instructions format
+  (`applyTo` frontmatter), **auto-synced** from upstream `canonical/copilot-collections`
+  (pinned in `.copilot-collections.yaml`) by the weekly `copilot-collections-update.yml`
+  workflow. The format/delivery is Copilot-specific, but most of the content
+  (code-commenting style, documentation rules, the charm-library-update review protocol) is
+  general guidance worth following regardless of tool.
 - `CONTRIBUTING.md` — dev workflow, coverage/complexity gates, the 12-factor reference.
 
 ### Keeping this file honest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,9 +59,9 @@ Charm logic should read full current state, act idempotently, and set unit statu
   pattern here (`GarmConfiguratorCharm._reconcile`): build state via
   `CharmState.from_charm(self)`, write relation data, set status once at the end.
 
-### Ops / Juju lifecycle idioms agents get wrong
+### Ops / Juju lifecycle idioms to take care of
 
-- **Secrets — owner vs observer** (a common mistake): `refresh=True` is an *observer* concept —
+- **Secrets — owner vs observer:** `refresh=True` is an *observer* concept —
   it advances the unit's *tracked* revision to the latest. Use it only when **consuming a
   secret you don't own** (an operator-supplied config secret, or one granted over a relation),
   especially in `secret-changed` handlers, so you read the new revision instead of the stale

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,38 +44,28 @@ These are **K8s 12-factor charms** on the `go-framework` charmcraft extension: a
 charm layer wraps a Go workload (`CONTRIBUTING.md` §"12 factor"; each `charmcraft.yaml`).
 `garm-configurator` is the exception — a plain `ops` charm.
 
-### Holistic state handling — but don't add a second reconcile
+### Holistic state handling
 
-Charm logic should read full current state, act idempotently, and set unit status once.
+Read full current state, act idempotently, and set unit status once.
 
-- **`paas_charm` charms (`garm`, `planner-operator`, `webhook-gateway-operator`)**: the base
-  class **already runs the holistic flow** (`PaasCharm.restart()`). Do **not** add a
-  `_reconcile` method. To inject behaviour, **override a framework hook** and call
-  `super()` — e.g. `restart()` (`garm`: write config + first-run; `planner-operator`: sync
-  relation endpoints) or `_create_app()` (`planner-operator`/`webhook-gateway-operator`:
-  inject OTel env). Gate on readiness with an early return (`if not self.is_ready(): return`),
-  not `event.defer()`.
-- **`garm-configurator`**: a single `_reconcile` that every event observes is the correct
-  pattern here (`GarmConfiguratorCharm._reconcile`): build state via
-  `CharmState.from_charm(self)`, write relation data, set status once at the end.
+For **`paas_charm` charms** (`garm`, `planner-operator`, `webhook-gateway-operator`) — the base class already runs the holistic flow (`PaasCharm.restart()`):
+
+- **DON'T** add a `_reconcile` method.
+- **DO** inject behaviour by overriding a framework hook and calling `super()` — e.g. `restart()` (`garm`: write config + first-run; `planner-operator`: sync relation endpoints) or `_create_app()` (`planner-operator`/`webhook-gateway-operator`: inject OTel env).
+- **DO** gate on readiness with an early return (`if not self.is_ready(): return`); **DON'T** call `event.defer()`.
+
+For **`garm-configurator`** (plain `ops`):
+
+- **DO** keep the single `_reconcile` that every event observes (`GarmConfiguratorCharm._reconcile`): build state via `CharmState.from_charm(self)`, write relation data, set status once at the end.
 
 ### Ops / Juju lifecycle idioms to take care of
 
-- **Secrets — owner vs observer:** `refresh=True` is an *observer* concept —
-  it advances the unit's *tracked* revision to the latest. Use it only when **consuming a
-  secret you don't own** (an operator-supplied config secret, or one granted over a relation),
-  especially in `secret-changed` handlers, so you read the new revision instead of the stale
-  tracked one — e.g. the `*.from_charm` resolvers in `charms/garm-configurator/src/charm_state.py`.
-  When you **own** the secret (created via `add_secret`), plain `get_content()` already returns
-  the latest revision (and `set_content()` invalidates the cache), so `refresh=True` is
-  unnecessary — e.g. `garm`'s `_get_secrets` / `_get_admin_credentials`. Use `peek_content()`
-  to read the latest revision without changing tracking. The leader creates labelled secrets so
-  other units can fetch them by `label`.
-- **Relation data carries the secret id/URI, never the content**: `add_secret(..., label=...)`
-  → `secret.grant(relation)` → `relation.data[self.app]["token"] = str(secret.id)`
-  (`planner-operator`'s `_create_relation_credentials`).
-- Prefer **readiness-gating** (`is_ready()` early-return) over `event.defer()`.
-- Relation databags are **string-only** — serialise (e.g. `json.dumps`) structured values.
+- **Secrets — owner vs observer.** `refresh=True` is an *observer* concept: it advances the unit's *tracked* revision to the latest.
+  - **DO** pass `get_content(refresh=True)` only when **consuming a secret you don't own** (an operator-supplied config secret, or one granted over a relation), especially in `secret-changed` handlers — e.g. the `*.from_charm` resolvers in `charms/garm-configurator/src/charm_state.py`.
+  - **DON'T** pass `refresh=True` for a secret you **own** (created via `add_secret`): plain `get_content()` already returns the latest revision and `set_content()` invalidates the cache — e.g. `garm`'s `_get_secrets` / `_get_admin_credentials`. Use `peek_content()` to read the latest without changing tracking.
+  - **DO** create labelled secrets on the leader so other units can fetch them by `label`.
+- **DO** put the secret id/URI in relation data; **DON'T** put the content: `add_secret(..., label=...)` → `secret.grant(relation)` → `relation.data[self.app]["token"] = str(secret.id)` (`planner-operator`'s `_create_relation_credentials`).
+- **DO** serialise structured values (e.g. `json.dumps`) — relation databags are string-only.
 
 ### Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,10 @@ guidance in `.github/instructions/` and the human-facing `CONTRIBUTING.md`.
 | `charms/` | Four Juju charms (see below) plus shared integration tests in `charms/tests/integration/`. |
 | `cmd/` | Go application entry points: `planner`, `webhook-gateway`. |
 | `internal/` | Shared Go packages (`database`, `github`, `planner`, `queue`, `server`, `telemetry`, `webhook`, …) — the application logic the paas charms package and deploy. |
-| `bundles/`, `images/` | Juju bundles and rock/image definitions. |
+| `bundles`, `images` | Juju bundles and rock/image definitions. |
 | `docs/` | Diátaxis-structured docs (Read the Docs). ADRs in `docs/adr/`. |
 | `actions/`, `runner_grafana_dashboards/` | A GitHub Action and runner-host dashboards. |
-| `parts/`, `prime/`, `stage/`, `**/lib/charms/**` | **Generated or vendored — do not edit.** `lib/charms/**` is auto-updated; see `.github/instructions/charms-lib-updates.instructions.md`. |
+| `parts`, `prime`, `stage`, `**/lib/charms/**` | **Generated or vendored — do not edit.** `lib/charms/**` is auto-updated; see `.github/instructions/charms-lib-updates.instructions.md`. |
 
 The Go layout follows the [community Go project layout](https://github.com/golang-standards/project-layout).
 `README.md` has the canonical layout (note: it predates the `garm` and `garm-configurator`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Claude Code reads CLAUDE.md, not AGENTS.md; this import bridges to the shared AGENTS.md (see https://agents.md). Add Claude-specific instructions below the import if ever needed. -->
+@AGENTS.md

--- a/charms/garm-configurator/AGENTS.md
+++ b/charms/garm-configurator/AGENTS.md
@@ -8,7 +8,8 @@ what's specific to `garm-configurator`.
 - **Holistic single `_reconcile` is correct here.** Every observed event funnels into
   `_reconcile` (`GarmConfiguratorCharm.__init__`); it builds full state via
   `CharmState.from_charm(self)`, forwards OpenStack credentials and scaleset config to the
-  relations, and sets unit status **once at the end**. Do not add per-event delta handlers.
+  relations, and sets unit status **once at the end**.
+  - **DON'T** add per-event delta handlers.
 - **State + secret resolution live in `src/charm_state.py`** (`CharmState`,
   `CharmConfigInvalidError`). This is also the repo's reference for the **observer** secret
   pattern: the `*.from_charm` resolvers read operator-supplied secret config (OpenStack

--- a/charms/garm-configurator/AGENTS.md
+++ b/charms/garm-configurator/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md — garm-configurator charm
+
+Configuration broker for GARM scalesets. Read the root `AGENTS.md` first; this file lists only
+what's specific to `garm-configurator`.
+
+- **Base: plain `ops.CharmBase`** — the only direct-`ops` charm in the repo (no `go-framework`
+  extension, no `paas_charm`). The canonical charm-engineer patterns apply here directly.
+- **Holistic single `_reconcile` is correct here.** Every observed event funnels into
+  `_reconcile` (`GarmConfiguratorCharm.__init__`); it builds full state via
+  `CharmState.from_charm(self)`, forwards OpenStack credentials and scaleset config to the
+  relations, and sets unit status **once at the end**. Do not add per-event delta handlers.
+- **State + secret resolution live in `src/charm_state.py`** (`CharmState`,
+  `CharmConfigInvalidError`). This is also the repo's reference for the **observer** secret
+  pattern: the `*.from_charm` resolvers read operator-supplied secret config (OpenStack
+  password, GitHub App private key) with `get_content(refresh=True)` because the *operator*
+  owns those secrets — `refresh=True` picks up the new revision on `secret-changed`. Validate
+  there and raise `CharmConfigInvalidError`; `_reconcile` turns it into a `BlockedStatus`.
+- Relation databags are string-only: serialise structured values (e.g. `pre_install_scripts`
+  via `json.dumps`).
+- Tests: Scenario-based unit tests in `tests/unit/test_charm.py`; integration via
+  `tox -e garm-configurator-integration`.

--- a/charms/garm-configurator/CLAUDE.md
+++ b/charms/garm-configurator/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Claude Code reads CLAUDE.md, not AGENTS.md; this import bridges to the sibling AGENTS.md. -->
+@AGENTS.md

--- a/charms/garm/AGENTS.md
+++ b/charms/garm/AGENTS.md
@@ -3,16 +3,13 @@
 GARM (GitHub Actions Runner Manager) charm. Read the root `AGENTS.md` first for the shared
 charm conventions; this file lists only what's specific to `garm`.
 
-- **Base: `paas_charm.go.Charm`.** Do **not** add a `_reconcile` method — the base class
-  reconciles. Inject behaviour by overriding `restart()`, which writes the GARM TOML config,
-  sets the Pebble command, and triggers admin first-run (`_maybe_first_run`).
-- **Readiness gate**, don't defer: `restart()` returns early when `not self.is_ready()`, and
-  short-circuits by reporting a status (rather than `event.defer()`) when PostgreSQL relation
-  data is missing (`_get_postgresql_config` returns `None`).
-- **Owner of two labelled juju secrets** — `GARM_SECRETS_LABEL` and
-  `GARM_ADMIN_CREDENTIALS_LABEL` — created leader-only in `_ensure_secrets`. As the **owner**,
-  read them with plain `get_content()` (`_get_secrets`, `_get_admin_credentials`); `refresh=True`
-  is an observer concept and is not needed here (see root `AGENTS.md`).
+- **Base: `paas_charm.go.Charm`** — the base class reconciles.
+  - **DON'T** add a `_reconcile` method.
+  - **DO** override `restart()` to inject behaviour: it writes the GARM TOML config, sets the Pebble command, and triggers admin first-run (`_maybe_first_run`).
+- **DO** gate on readiness; **DON'T** defer: `restart()` returns early when `not self.is_ready()`, and short-circuits by reporting a status when PostgreSQL relation data is missing (`_get_postgresql_config` returns `None`).
+- **Secrets (owner).** `garm` owns two labelled juju secrets — `GARM_SECRETS_LABEL` and `GARM_ADMIN_CREDENTIALS_LABEL` — created leader-only in `_ensure_secrets`.
+  - **DO** read them with plain `get_content()` (`_get_secrets`, `_get_admin_credentials`).
+  - **DON'T** pass `refresh=True` — that's an observer concept (see root `AGENTS.md`).
 - **Domain logic is factored out of `charm.py`**: `src/garm_api.py` and `src/garm_client/`
   (the GARM HTTP client). Extend these rather than growing the charm class. TOML rendering:
   `render_garm_toml()` in `src/charm.py`.

--- a/charms/garm/AGENTS.md
+++ b/charms/garm/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md — garm charm
+
+GARM (GitHub Actions Runner Manager) charm. Read the root `AGENTS.md` first for the shared
+charm conventions; this file lists only what's specific to `garm`.
+
+- **Base: `paas_charm.go.Charm`.** Do **not** add a `_reconcile` method — the base class
+  reconciles. Inject behaviour by overriding `restart()`, which writes the GARM TOML config,
+  sets the Pebble command, and triggers admin first-run (`_maybe_first_run`).
+- **Readiness gate**, don't defer: `restart()` returns early when `not self.is_ready()` and
+  sets a `BlockedStatus` when PostgreSQL relation data is missing (`_get_postgresql_config`
+  returns `None`).
+- **Owner of two labelled juju secrets** — `GARM_SECRETS_LABEL` and
+  `GARM_ADMIN_CREDENTIALS_LABEL` — created leader-only in `_ensure_secrets`. As the **owner**,
+  read them with plain `get_content()` (`_get_secrets`, `_get_admin_credentials`); `refresh=True`
+  is an observer concept and is not needed here (see root `AGENTS.md`).
+- **Domain logic is factored out of `charm.py`**: `src/garm_api.py` and `src/garm_client/`
+  (the GARM HTTP client). Extend these rather than growing the charm class. TOML rendering:
+  `render_garm_toml()` in `src/charm.py`.
+- GARM serves its API and `/metrics` on one fixed port (`GARM_PORT`); the `app-port` /
+  `metrics-port` / `metrics-path` config options have no effect (the charm logs a warning
+  rather than blocking). The port is pinned in the `_workload_config` property.
+- Tests: unit in `tests/unit/`; integration via `tox -e garm-integration`
+  (`charms/tests/integration/test_garm.py`).

--- a/charms/garm/AGENTS.md
+++ b/charms/garm/AGENTS.md
@@ -6,9 +6,9 @@ charm conventions; this file lists only what's specific to `garm`.
 - **Base: `paas_charm.go.Charm`.** Do **not** add a `_reconcile` method — the base class
   reconciles. Inject behaviour by overriding `restart()`, which writes the GARM TOML config,
   sets the Pebble command, and triggers admin first-run (`_maybe_first_run`).
-- **Readiness gate**, don't defer: `restart()` returns early when `not self.is_ready()` and
-  sets a `BlockedStatus` when PostgreSQL relation data is missing (`_get_postgresql_config`
-  returns `None`).
+- **Readiness gate**, don't defer: `restart()` returns early when `not self.is_ready()`, and
+  short-circuits by reporting a status (rather than `event.defer()`) when PostgreSQL relation
+  data is missing (`_get_postgresql_config` returns `None`).
 - **Owner of two labelled juju secrets** — `GARM_SECRETS_LABEL` and
   `GARM_ADMIN_CREDENTIALS_LABEL` — created leader-only in `_ensure_secrets`. As the **owner**,
   read them with plain `get_content()` (`_get_secrets`, `_get_admin_credentials`); `refresh=True`

--- a/charms/garm/CLAUDE.md
+++ b/charms/garm/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Claude Code reads CLAUDE.md, not AGENTS.md; this import bridges to the sibling AGENTS.md. -->
+@AGENTS.md

--- a/charms/planner-operator/AGENTS.md
+++ b/charms/planner-operator/AGENTS.md
@@ -3,15 +3,12 @@
 GitHub runner planner API charm. Read the root `AGENTS.md` first; this file lists only what's
 specific to `planner-operator`.
 
-- **Base: `paas_charm.go.Charm`.** Do **not** add a `_reconcile` method — the base class
-  reconciles. This charm overrides two framework hooks (always wrapping `super()`):
-  `_create_app()` injects OpenTelemetry environment variables, and `restart()` holistically
-  syncs the planner relation endpoints on every restart.
-- **Sharing credentials over a relation**: create a labelled secret, grant it to the relation,
-  and put the secret **id** (not the token) in the databag —
-  `add_secret({"token": …}, label=…)` → `secret.grant(relation)` →
-  `relation.data[self.app]["token"] = str(secret.id)` (see `_create_relation_credentials`).
-  Clean up orphaned tokens with `remove_all_revisions()` (`_delete_orphaned_credentials`).
+- **Base: `paas_charm.go.Charm`** — the base class reconciles.
+  - **DON'T** add a `_reconcile` method.
+  - **DO** override framework hooks (always wrapping `super()`): `_create_app()` injects OpenTelemetry environment variables, and `restart()` holistically syncs the planner relation endpoints on every restart.
+- **Sharing credentials over a relation** (see `_create_relation_credentials`):
+  - **DO** put the secret **id** in the databag, not the token — `add_secret({"token": …}, label=…)` → `secret.grant(relation)` → `relation.data[self.app]["token"] = str(secret.id)`.
+  - **DO** clean up orphaned tokens with `remove_all_revisions()` (`_delete_orphaned_credentials`).
 - The Go workload lives in `cmd/planner/` + `internal/`; charm changes that affect the API
   often pair with changes there.
 - Tests: unit in `tests/unit/`; integration via `tox -e planner-integration`.

--- a/charms/planner-operator/AGENTS.md
+++ b/charms/planner-operator/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md — planner-operator charm
+
+GitHub runner planner API charm. Read the root `AGENTS.md` first; this file lists only what's
+specific to `planner-operator`.
+
+- **Base: `paas_charm.go.Charm`.** Do **not** add a `_reconcile` method — the base class
+  reconciles. This charm overrides two framework hooks (always wrapping `super()`):
+  `_create_app()` injects OpenTelemetry environment variables, and `restart()` holistically
+  syncs the planner relation endpoints on every restart.
+- **Sharing credentials over a relation**: create a labelled secret, grant it to the relation,
+  and put the secret **id** (not the token) in the databag —
+  `add_secret({"token": …}, label=…)` → `secret.grant(relation)` →
+  `relation.data[self.app]["token"] = str(secret.id)` (see `_create_relation_credentials`).
+  Clean up orphaned tokens with `remove_all_revisions()` (`_delete_orphaned_credentials`).
+- The Go workload lives in `cmd/planner/` + `internal/`; charm changes that affect the API
+  often pair with changes there.
+- Tests: unit in `tests/unit/`; integration via `tox -e planner-integration`.

--- a/charms/planner-operator/CLAUDE.md
+++ b/charms/planner-operator/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Claude Code reads CLAUDE.md, not AGENTS.md; this import bridges to the sibling AGENTS.md. -->
+@AGENTS.md

--- a/charms/webhook-gateway-operator/AGENTS.md
+++ b/charms/webhook-gateway-operator/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md — webhook-gateway-operator charm
+
+GitHub webhook receiver/forwarder charm. Read the root `AGENTS.md` first; this file lists only
+what's specific to `webhook-gateway-operator`.
+
+- **Base: `paas_charm.go.Charm`.** Do **not** add a `_reconcile` method — the base class
+  reconciles. The charm's only customisation is overriding `_create_app()` to inject
+  OpenTelemetry environment variables; wrap `super()._create_app()`, don't replace it.
+- The framework owns the workload — there is no hand-written Pebble layer here. The Go workload
+  (HMAC-validate the webhook, forward the job event to the AMQP broker) lives in
+  `cmd/webhook-gateway/` + `internal/`.
+- Tests: unit in `tests/unit/`; integration via `tox -e webhook-gateway-integration`.

--- a/charms/webhook-gateway-operator/AGENTS.md
+++ b/charms/webhook-gateway-operator/AGENTS.md
@@ -3,9 +3,9 @@
 GitHub webhook receiver/forwarder charm. Read the root `AGENTS.md` first; this file lists only
 what's specific to `webhook-gateway-operator`.
 
-- **Base: `paas_charm.go.Charm`.** Do **not** add a `_reconcile` method — the base class
-  reconciles. The charm's only customisation is overriding `_create_app()` to inject
-  OpenTelemetry environment variables; wrap `super()._create_app()`, don't replace it.
+- **Base: `paas_charm.go.Charm`** — the base class reconciles.
+  - **DON'T** add a `_reconcile` method.
+  - **DO** override `_create_app()` to inject OpenTelemetry environment variables — wrap `super()._create_app()`, **DON'T** replace it.
 - The framework owns the workload — there is no hand-written Pebble layer here. The Go workload
   (HMAC-validate the webhook, forward the job event to the AMQP broker) lives in
   `cmd/webhook-gateway/` + `internal/`.

--- a/charms/webhook-gateway-operator/CLAUDE.md
+++ b/charms/webhook-gateway-operator/CLAUDE.md
@@ -1,0 +1,2 @@
+<!-- Claude Code reads CLAUDE.md, not AGENTS.md; this import bridges to the sibling AGENTS.md. -->
+@AGENTS.md

--- a/scripts/check_agents_md.py
+++ b/scripts/check_agents_md.py
@@ -26,9 +26,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIRST_PARTY = ("charms", "cmd", "internal")
-EXCLUDE_DIRS = {".git", ".tox", "lib", "parts", "prime", "stage", "vendor", "build"}
+# "tests" is excluded so a private-method citation can't be satisfied by a
+# same-named helper in a test file when the real charm method is renamed/removed.
+EXCLUDE_DIRS = {".git", ".tox", "lib", "parts", "prime", "stage", "vendor", "build", "tests"}
 
-PATH_EXTENSIONS = ("py", "toml", "yaml", "yml", "ini", "md", "cfg", "txt")
+PATH_EXTENSIONS = ("py", "go", "toml", "yaml", "yml", "ini", "md", "cfg", "txt")
 BACKTICK = re.compile(r"`([^`]+)`")
 TOX_ENV = re.compile(r"tox -e ([\w-]+)")
 PRIVATE_METHOD = re.compile(r"^_[a-z]\w*$")
@@ -107,12 +109,14 @@ def _private_method(token: str) -> str | None:
 
 def _defines_method(roots: list[Path], method: str) -> bool:
     """True if any first-party Python file under a root defines the method."""
-    needle = f"def {method}"
+    # Anchor on the name followed by "(" so `def _reconcile_state` does not
+    # satisfy a citation for `_reconcile`.
+    pattern = re.compile(rf"def {re.escape(method)}\s*\(")
     for root in roots:
         for py in root.rglob("*.py"):
             if _excluded(py):
                 continue
-            if needle in py.read_text(encoding="utf-8"):
+            if pattern.search(py.read_text(encoding="utf-8")):
                 return True
     return False
 
@@ -133,7 +137,7 @@ def _collect_tox_envs() -> set[str]:
 
 
 def _excluded(path: Path) -> bool:
-    """True if the path lives in a vendored, generated, or build directory."""
+    """True if the path lives in a vendored, generated, build, or test directory."""
     return any(part in EXCLUDE_DIRS for part in path.parts)
 
 

--- a/scripts/check_agents_md.py
+++ b/scripts/check_agents_md.py
@@ -74,7 +74,9 @@ def _check_file(agents_md: Path, tox_envs: set[str]) -> list[str]:
 
     for token in {t.strip() for t in BACKTICK.findall(text)}:
         if _is_path(token):
-            if not any((root / token.rstrip("/")).exists() for root in path_roots):
+            if ".." in token.split("/"):
+                errors.append(f"{rel}: path `{token}` must be repo-relative (no '..')")
+            elif not any((root / token.rstrip("/")).exists() for root in path_roots):
                 errors.append(f"{rel}: path `{token}` does not exist")
             continue
         method = _private_method(token)

--- a/scripts/check_agents_md.py
+++ b/scripts/check_agents_md.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Guard against rot in the AGENTS.md guidance files.
+
+AGENTS.md files cite source files, private methods, and tox environments by name.
+Those citations silently go stale when code is renamed or moved. This script
+re-validates every machine-checkable citation so CI fails loudly instead.
+
+It deliberately checks only citation kinds that are unambiguous (near-zero false
+positives); prose, bare filenames, and public/library symbol names are left to
+human review. Checked kinds, all written inside `backticks`:
+
+* paths      — explicit relative paths (contain "/", end in a known extension or
+               a trailing "/"), e.g. `src/charm.py`, `cmd/planner/`. Bare
+               filenames, globs, and absolute paths are skipped as too ambiguous.
+* methods    — leading-underscore identifiers (our private charm methods), e.g.
+               `_reconcile`, `_create_app`; verified to exist as a `def`.
+* tox envs   — `tox -e <name>`; verified against tox.ini.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIRST_PARTY = ("charms", "cmd", "internal")
+EXCLUDE_DIRS = {".git", ".tox", "lib", "parts", "prime", "stage", "vendor", "build"}
+
+PATH_EXTENSIONS = ("py", "toml", "yaml", "yml", "ini", "md", "cfg", "txt")
+BACKTICK = re.compile(r"`([^`]+)`")
+TOX_ENV = re.compile(r"tox -e ([\w-]+)")
+PRIVATE_METHOD = re.compile(r"^_[a-z]\w*$")
+
+
+def main() -> int:
+    """Validate citations in every first-party AGENTS.md and report breakage."""
+    tox_envs = _collect_tox_envs()
+    errors: list[str] = []
+    for agents_md in sorted(REPO_ROOT.rglob("AGENTS.md")):
+        if _excluded(agents_md):
+            continue
+        errors.extend(_check_file(agents_md, tox_envs))
+
+    if errors:
+        print("Broken citations in AGENTS.md files:\n")
+        print("\n".join(errors))
+        print(f"\n{len(errors)} broken citation(s). Update the AGENTS.md or the code.")
+        return 1
+    print("AGENTS.md citations OK.")
+    return 0
+
+
+def _check_file(agents_md: Path, tox_envs: set[str]) -> list[str]:
+    """Return one error string per broken citation in a single AGENTS.md."""
+    rel = agents_md.relative_to(REPO_ROOT)
+    text = agents_md.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    for env in TOX_ENV.findall(text):
+        if env not in tox_envs:
+            errors.append(f"{rel}: unknown tox env `tox -e {env}`")
+
+    # Per-charm files cite paths relative to their own dir; the root file cites
+    # them relative to the repo. Resolve against both. A private method is
+    # accepted if it exists anywhere in first-party code: this catches a full
+    # rename/removal while tolerating `_reconcile`, which the paas-charm files
+    # name only to warn against adding one (it lives in garm-configurator).
+    path_roots = [agents_md.parent, REPO_ROOT]
+    method_roots = [REPO_ROOT / d for d in FIRST_PARTY]
+
+    for token in {t.strip() for t in BACKTICK.findall(text)}:
+        if _is_path(token):
+            if not any((root / token.rstrip("/")).exists() for root in path_roots):
+                errors.append(f"{rel}: path `{token}` does not exist")
+            continue
+        method = _private_method(token)
+        if method and not _defines_method(method_roots, method):
+            errors.append(f"{rel}: no `def {method}` found for citation `{token}`")
+    return errors
+
+
+def _is_path(token: str) -> bool:
+    """True only for explicit relative paths; ambiguous tokens are skipped.
+
+    Requires a slash so dotted modules and bare prose words are ignored, rejects
+    globs and absolute paths, and requires either a trailing slash (a directory)
+    or a known file extension so prose like `try/except` is not treated as a path.
+    """
+    if "/" not in token or token.startswith("/"):
+        return False
+    if any(c in token for c in " (*"):
+        return False
+    return token.endswith("/") or token.rsplit(".", 1)[-1] in PATH_EXTENSIONS
+
+
+def _private_method(token: str) -> str | None:
+    """Extract a leading-underscore method name from a citation, else None.
+
+    Handles bare (`_reconcile`), called (`_reconcile()`), and qualified
+    (`GarmConfiguratorCharm._reconcile`) forms.
+    """
+    name = token.split("(", 1)[0].rsplit(".", 1)[-1]
+    return name if PRIVATE_METHOD.match(name) else None
+
+
+def _defines_method(roots: list[Path], method: str) -> bool:
+    """True if any first-party Python file under a root defines the method."""
+    needle = f"def {method}"
+    for root in roots:
+        for py in root.rglob("*.py"):
+            if _excluded(py):
+                continue
+            if needle in py.read_text(encoding="utf-8"):
+                return True
+    return False
+
+
+def _collect_tox_envs() -> set[str]:
+    """Gather valid tox env names from env_list and [testenv:NAME] headers."""
+    envs: set[str] = set()
+    tox_ini = REPO_ROOT / "tox.ini"
+    if not tox_ini.exists():
+        return envs
+    for line in tox_ini.read_text(encoding="utf-8").splitlines():
+        header = re.match(r"\[testenv:([\w-]+)\]", line.strip())
+        if header:
+            envs.add(header.group(1))
+        elif line.strip().startswith("env_list"):
+            envs.update(e.strip() for e in line.split("=", 1)[1].split(","))
+    return envs
+
+
+def _excluded(path: Path) -> bool:
+    """True if the path lives in a vendored, generated, or build directory."""
+    return any(part in EXCLUDE_DIRS for part in path.parts)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_agents_md.py
+++ b/scripts/check_agents_md.py
@@ -72,7 +72,7 @@ def _check_file(agents_md: Path, tox_envs: set[str]) -> list[str]:
     path_roots = [agents_md.parent, REPO_ROOT]
     method_roots = [REPO_ROOT / d for d in FIRST_PARTY]
 
-    for token in {t.strip() for t in BACKTICK.findall(text)}:
+    for token in dict.fromkeys(t.strip() for t in BACKTICK.findall(text)):
         if _is_path(token):
             if ".." in token.split("/"):
                 errors.append(f"{rel}: path `{token}` must be repo-relative (no '..')")


### PR DESCRIPTION
> **Note:** We want an `AGENTS.md` baseline in place now. The approach may still evolve, so treat this as a starting point rather than the final word.

#### What this PR does

Adds `AGENTS.md` agent guidance (root + one per charm) following the cross-tool [AGENTS.md](https://agents.md) standard, plus:
- A `CLAUDE.md` next to each that imports it (`@AGENTS.md`), so Claude Code reads the same guidance.
- A CI check (`scripts/check_agents_md.py` + workflow) that fails on stale path / method / `tox` citations.
- Two PR-template items to keep the guidance current.

#### Why we need it

To align how AI agents work in this repo: document the 12-factor / paas-charm conventions (e.g. paas charms override `restart()` / `_create_app()` instead of adding a second `_reconcile`) and the ops/Juju secret idioms, complementing the existing `.github/instructions/`.

#### Checklist

- [x] Changes comply with coding standards (CONTRIBUTING.md, STYLE.md)
- [ ] `CONTRIBUTING.md` updated — N/A (no dev-process change)
- [ ] Technical author assigned — no TA for AGENTS.md required
- [ ] `docs/changelog.md` updated — N/A (not user-facing)
- [x] I used AI to assist with preparing this PR
- [ ] Tests added — the new check is CI-enforced; it has no unit test of its own
- [ ] Integration modules / Grafana / Terraform / Rockcraft — N/A
- [x] Adds tooling/docs → updated the relevant `AGENTS.md`
- [ ] Changes `.copilot-collections.yaml` / `.github/instructions/` — N/A

#### Test plan

`python3 scripts/check_agents_md.py` passes locally and against a clean checkout; wired into the `agents_md_check` workflow.

#### Review focus

- The approach is a baseline and may evolve — feedback on structure welcome.
- Accuracy of the documented 12-factor conventions and secret idioms.

No runtime or charm-behaviour changes (docs + CI only).
