### PR TITLE
fix(planner): match runner labels case-insensitively

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-18
+
+- match planner runner labels case-insensitively, so jobs requesting GitHub's implicit label casing (e.g. `X64`, `Linux`) match flavors defined in lowercase. A migration lowercases existing labels and re-assigns jobs previously left unmatched due to casing.
+
 ## 2026-06-16
 
 - Add Garm configurator relation with GARM charm and write OpenStack provider related toml configurations.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-06-18
 
-- match planner runner labels case-insensitively, so jobs requesting GitHub's implicit label casing (e.g. `X64`, `Linux`) match flavors defined in lowercase. A migration lowercases existing labels and re-assigns jobs previously left unmatched due to casing.
+- match planner runner labels case-insensitively, so jobs requesting GitHub's implicit label casing (e.g. `X64`, `Linux`) match flavors defined in lowercase. A migration lowercases existing labels and reassigns jobs previously left unmatched due to casing.
 
 ## 2026-06-16
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-06-18
 
-- match planner runner labels case-insensitively, so jobs requesting GitHub's implicit label casing (e.g. `X64`, `Linux`) match flavors defined in lowercase. A migration lowercases existing labels and reassigns jobs previously left unmatched due to casing.
+- match planner runner labels case-insensitively, so jobs requesting GitHub's implicit label casing (e.g. `X64`, `Linux`) match flavors defined in lowercase. A migration converts existing labels to lowercase and reassigns jobs previously left unmatched due to casing.
 
 ## 2026-06-16
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -13,6 +13,9 @@
 // When a job is inserted, it is assigned a flavor using the following algorithm:
 //  1. The flavor's platform must match the job's platform.
 //  2. The flavor's labels must be a superset of (or equal to) the job's labels.
+//     Matching is case-insensitive: both flavor and job labels are normalized to
+//     lowercase on insertion, since GitHub injects architecture/OS labels (e.g.
+//     "X64", "Linux") with casing that differs from how flavors are defined.
 //  3. If multiple flavors match, choose the one with the highest priority.
 //  4. If there is still a tie, pick one at random.
 package database
@@ -25,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -58,6 +62,8 @@ const (
 // GitHub automatically adds these labels to all self-hosted runner jobs.
 // They are stripped from job labels on insertion so they don't interfere
 // with flavor matching. The original labels are preserved in the raw payload.
+// Keys must be lowercase: stripDefaultLabels lowercases each label before
+// comparing, so stripping is case-insensitive.
 var defaultGitHubLabels = map[string]struct{}{
 	"self-hosted": {},
 	"linux":       {},
@@ -357,7 +363,7 @@ func (d *Database) AddFlavor(ctx context.Context, flavor *Flavor) error {
 	`, pgx.NamedArgs{
 		"platform":         flavor.Platform,
 		"name":             flavor.Name,
-		"labels":           flavor.Labels,
+		"labels":           lowercaseLabels(flavor.Labels),
 		"priority":         flavor.Priority,
 		"is_disabled":      flavor.IsDisabled,
 		"minimum_pressure": flavor.MinimumPressure,
@@ -636,12 +642,27 @@ func (d *Database) Close() {
 	}
 }
 
+// stripDefaultLabels normalizes labels to lowercase and removes GitHub's
+// implicit labels (see defaultGitHubLabels). Lowercasing makes both the strip
+// and downstream flavor matching case-insensitive.
 func stripDefaultLabels(labels []string) []string {
 	filtered := make([]string, 0, len(labels))
 	for _, l := range labels {
+		l = strings.ToLower(l)
 		if _, ok := defaultGitHubLabels[l]; !ok {
 			filtered = append(filtered, l)
 		}
 	}
 	return filtered
+}
+
+// lowercaseLabels normalizes labels to lowercase. Flavor labels are stored
+// lowercase so that matching against (also lowercased) job labels is
+// case-insensitive.
+func lowercaseLabels(labels []string) []string {
+	lowered := make([]string, len(labels))
+	for i, l := range labels {
+		lowered[i] = strings.ToLower(l)
+	}
+	return lowered
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -606,7 +606,11 @@ func TestMigration0002_LowercaseLabels(t *testing.T) {
 		  ('github', 'completed',  ARRAY['self-hosted','Linux','X64','Noble'], now(), now(), NULL),
 		  -- Already-normalized, unassigned job: skipped by the label-rewrite guard
 		  -- but must still be picked up by the reassignment step.
-		  ('github', 'normalized', ARRAY['x64','noble'], now(), NULL, NULL);
+		  ('github', 'normalized', ARRAY['x64','noble'], now(), NULL, NULL),
+		  -- Assigned but in-progress job: its labels must be normalized too (so a
+		  -- later flavor change that re-matches it still works) while keeping its
+		  -- existing assignment.
+		  ('github', 'assigned', ARRAY['X64','Noble'], now(), NULL, 'github-x64-noble');
 	`, pgx.QueryExecModeSimpleProtocol)
 	require.NoError(t, err)
 
@@ -642,6 +646,14 @@ func TestMigration0002_LowercaseLabels(t *testing.T) {
 	assert.Equal(t, []string{"x64", "noble"}, normLabels)
 	require.NotNil(t, normFlavor)
 	assert.Equal(t, "github-x64-noble", *normFlavor)
+
+	var asgLabels []string
+	var asgFlavor *string
+	require.NoError(t, db.conn.QueryRow(ctx,
+		`SELECT labels, assigned_flavor FROM job WHERE id = 'assigned'`).Scan(&asgLabels, &asgFlavor))
+	assert.Equal(t, []string{"x64", "noble"}, asgLabels)
+	require.NotNil(t, asgFlavor)
+	assert.Equal(t, "github-x64-noble", *asgFlavor)
 }
 
 func TestDatabase_AddFlavor_Exists(t *testing.T) {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -339,6 +339,33 @@ func TestDatabase_AddJob_DefaultLabelsStripped(t *testing.T) {
 	assert.Equal(t, []string{"x64", "noble"}, jobs[0].Labels)
 }
 
+// Verify that flavor matching is case-insensitive: GitHub injects the
+// architecture/OS labels with its own casing (e.g. "X64", "Linux"), which must
+// still match flavors defined with lowercase labels.
+func TestDatabase_AddJob_CaseInsensitiveFlavorMatching(t *testing.T) {
+	db := setupDatabase(t)
+	defer teardownDatabase(t)
+	ctx := t.Context()
+
+	assert.NoError(t, db.AddFlavor(ctx, &Flavor{
+		Platform: "github",
+		Name:     "github-x64-noble",
+		Labels:   []string{"x64", "noble"},
+		Priority: 100,
+	}))
+
+	assert.NoError(t, db.AddJob(ctx, &Job{
+		Platform: "github",
+		ID:       "1",
+		Labels:   []string{"self-hosted", "Linux", "X64", "Noble"},
+	}))
+
+	jobs, err := db.ListJobs(ctx, "github", ListJobOptions{WithId: "1"})
+	assert.NoError(t, err)
+	assert.Equal(t, "github-x64-noble", *jobs[0].AssignedFlavor)
+	assert.Equal(t, []string{"x64", "noble"}, jobs[0].Labels)
+}
+
 func TestDatabase_AddJob_EqualPriority(t *testing.T) {
 	db := setupDatabase(t)
 	defer teardownDatabase(t)
@@ -536,6 +563,24 @@ func TestDatabase_AddFlavor(t *testing.T) {
 
 	assert.Len(t, jobs, 1)
 	assert.Equal(t, flavor.Name, *jobs[0].AssignedFlavor)
+}
+
+// Verify that flavor labels are stored lowercase so that matching against
+// (also lowercased) job labels is case-insensitive.
+func TestDatabase_AddFlavor_LowercasesLabels(t *testing.T) {
+	db := setupDatabase(t)
+	defer teardownDatabase(t)
+	ctx := t.Context()
+
+	assert.NoError(t, db.AddFlavor(ctx, &Flavor{
+		Platform: "github",
+		Name:     "amd64-large",
+		Labels:   []string{"Self-Hosted", "AMD64", "Large"},
+	}))
+
+	flavor, err := db.GetFlavor(ctx, "amd64-large")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"self-hosted", "amd64", "large"}, flavor.Labels)
 }
 
 func TestDatabase_AddFlavor_Exists(t *testing.T) {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -583,6 +583,56 @@ func TestDatabase_AddFlavor_LowercasesLabels(t *testing.T) {
 	assert.Equal(t, []string{"self-hosted", "amd64", "large"}, flavor.Labels)
 }
 
+// Verify the 0002 data backfill against rows stored the way the old
+// case-sensitive code wrote them. The backfill lives only in raw SQL (the app's
+// forward path can't be reused from golang-migrate), so this exercises the exact
+// shipped migration file: it must lowercase flavor labels, lowercase and strip
+// implicit labels from incomplete jobs, reassign jobs that only failed to match
+// because of casing, and leave completed jobs as historical data.
+func TestMigration0002_LowercaseLabels(t *testing.T) {
+	db := setupDatabase(t)
+	defer teardownDatabase(t)
+	ctx := t.Context()
+
+	// Seed pre-migration rows with raw INSERTs so mixed-case labels are stored
+	// verbatim, bypassing the lowercasing setters and reproducing production state.
+	_, err := db.conn.Exec(ctx, `
+		INSERT INTO flavor (platform, name, labels, priority)
+		VALUES ('github', 'github-x64-noble', ARRAY['X64','Noble'], 100);
+
+		INSERT INTO job (platform, id, labels, created_at, completed_at, assigned_flavor)
+		VALUES
+		  ('github', 'incomplete', ARRAY['self-hosted','Linux','X64','Noble'], now(), NULL, NULL),
+		  ('github', 'completed',  ARRAY['self-hosted','Linux','X64','Noble'], now(), now(), NULL);
+	`, pgx.QueryExecModeSimpleProtocol)
+	require.NoError(t, err)
+
+	migrationSQL, err := migrationsFS.ReadFile("migrations/0002_lowercase_labels.up.sql")
+	require.NoError(t, err)
+	_, err = db.conn.Exec(ctx, string(migrationSQL), pgx.QueryExecModeSimpleProtocol)
+	require.NoError(t, err)
+
+	var flavorLabels []string
+	require.NoError(t, db.conn.QueryRow(ctx,
+		`SELECT labels FROM flavor WHERE name = 'github-x64-noble'`).Scan(&flavorLabels))
+	assert.Equal(t, []string{"x64", "noble"}, flavorLabels)
+
+	var incLabels []string
+	var incFlavor *string
+	require.NoError(t, db.conn.QueryRow(ctx,
+		`SELECT labels, assigned_flavor FROM job WHERE id = 'incomplete'`).Scan(&incLabels, &incFlavor))
+	assert.Equal(t, []string{"x64", "noble"}, incLabels)
+	require.NotNil(t, incFlavor)
+	assert.Equal(t, "github-x64-noble", *incFlavor)
+
+	var compLabels []string
+	var compFlavor *string
+	require.NoError(t, db.conn.QueryRow(ctx,
+		`SELECT labels, assigned_flavor FROM job WHERE id = 'completed'`).Scan(&compLabels, &compFlavor))
+	assert.Equal(t, []string{"self-hosted", "Linux", "X64", "Noble"}, compLabels)
+	assert.Nil(t, compFlavor)
+}
+
 func TestDatabase_AddFlavor_Exists(t *testing.T) {
 	db := setupDatabase(t)
 	defer teardownDatabase(t)

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -603,7 +603,10 @@ func TestMigration0002_LowercaseLabels(t *testing.T) {
 		INSERT INTO job (platform, id, labels, created_at, completed_at, assigned_flavor)
 		VALUES
 		  ('github', 'incomplete', ARRAY['self-hosted','Linux','X64','Noble'], now(), NULL, NULL),
-		  ('github', 'completed',  ARRAY['self-hosted','Linux','X64','Noble'], now(), now(), NULL);
+		  ('github', 'completed',  ARRAY['self-hosted','Linux','X64','Noble'], now(), now(), NULL),
+		  -- Already-normalized, unassigned job: skipped by the label-rewrite guard
+		  -- but must still be picked up by the reassignment step.
+		  ('github', 'normalized', ARRAY['x64','noble'], now(), NULL, NULL);
 	`, pgx.QueryExecModeSimpleProtocol)
 	require.NoError(t, err)
 
@@ -631,6 +634,14 @@ func TestMigration0002_LowercaseLabels(t *testing.T) {
 		`SELECT labels, assigned_flavor FROM job WHERE id = 'completed'`).Scan(&compLabels, &compFlavor))
 	assert.Equal(t, []string{"self-hosted", "Linux", "X64", "Noble"}, compLabels)
 	assert.Nil(t, compFlavor)
+
+	var normLabels []string
+	var normFlavor *string
+	require.NoError(t, db.conn.QueryRow(ctx,
+		`SELECT labels, assigned_flavor FROM job WHERE id = 'normalized'`).Scan(&normLabels, &normFlavor))
+	assert.Equal(t, []string{"x64", "noble"}, normLabels)
+	require.NotNil(t, normFlavor)
+	assert.Equal(t, "github-x64-noble", *normFlavor)
 }
 
 func TestDatabase_AddFlavor_Exists(t *testing.T) {

--- a/internal/database/labels_test.go
+++ b/internal/database/labels_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Canonical Ltd.
+ * Copyright 2026 Canonical Ltd.
  * See LICENSE file for licensing details.
  */
 

--- a/internal/database/labels_test.go
+++ b/internal/database/labels_test.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 Canonical Ltd.
+ * See LICENSE file for licensing details.
+ */
+
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// stripDefaultLabels normalizes labels to lowercase and removes GitHub's
+// implicit labels case-insensitively, so flavor matching is unaffected by the
+// casing GitHub uses for the architecture/OS labels it injects.
+func TestStripDefaultLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels []string
+		want   []string
+	}{{
+		name:   "lowercases mixed-case labels",
+		labels: []string{"X64", "Large", "Noble"},
+		want:   []string{"x64", "large", "noble"},
+	}, {
+		name:   "strips default labels regardless of casing",
+		labels: []string{"Self-Hosted", "Linux", "X64"},
+		want:   []string{"x64"},
+	}, {
+		name:   "strips already-lowercase default labels",
+		labels: []string{"self-hosted", "linux", "amd64"},
+		want:   []string{"amd64"},
+	}, {
+		name:   "returns empty for only default labels",
+		labels: []string{"self-hosted", "LINUX"},
+		want:   []string{},
+	}, {
+		name:   "handles empty input",
+		labels: []string{},
+		want:   []string{},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, stripDefaultLabels(tc.labels))
+		})
+	}
+}

--- a/internal/database/migrations/0002_lowercase_labels.down.sql
+++ b/internal/database/migrations/0002_lowercase_labels.down.sql
@@ -1,5 +1,0 @@
--- Copyright 2025 Canonical Ltd.
--- See LICENSE file for licensing details.
-
--- Irreversible data normalization: the original label casing is not retained,
--- so there is nothing to roll back. No-op.

--- a/internal/database/migrations/0002_lowercase_labels.down.sql
+++ b/internal/database/migrations/0002_lowercase_labels.down.sql
@@ -1,0 +1,5 @@
+-- Copyright 2025 Canonical Ltd.
+-- See LICENSE file for licensing details.
+
+-- Irreversible data normalization: the original label casing is not retained,
+-- so there is nothing to roll back. No-op.

--- a/internal/database/migrations/0002_lowercase_labels.down.sql
+++ b/internal/database/migrations/0002_lowercase_labels.down.sql
@@ -1,0 +1,12 @@
+-- Copyright 2026 Canonical Ltd.
+-- See LICENSE file for licensing details.
+
+-- This migration normalizes label casing irreversibly: the original casing of
+-- existing flavor and job labels is not retained, so there is nothing to roll
+-- back to. Fail loudly with a clear reason rather than silently "succeeding" as
+-- a no-op (which would leave the data normalized while claiming a rollback) or
+-- failing with an opaque file-not-found error.
+DO $$
+BEGIN
+    RAISE EXCEPTION 'migration 0002_lowercase_labels is irreversible: original label casing is not retained and cannot be restored';
+END $$;

--- a/internal/database/migrations/0002_lowercase_labels.up.sql
+++ b/internal/database/migrations/0002_lowercase_labels.up.sql
@@ -1,4 +1,4 @@
--- Copyright 2025 Canonical Ltd.
+-- Copyright 2026 Canonical Ltd.
 -- See LICENSE file for licensing details.
 
 -- Flavor matching became case-insensitive: labels are now normalized to

--- a/internal/database/migrations/0002_lowercase_labels.up.sql
+++ b/internal/database/migrations/0002_lowercase_labels.up.sql
@@ -14,12 +14,15 @@ SET labels = (
 )
 WHERE f.labels::text <> lower(f.labels::text);
 
--- Normalize labels of jobs still needing a runner the same way ingestion does:
--- lowercase and strip GitHub's implicit labels (self-hosted, linux). The old
--- case-sensitive strip left uppercased implicit labels (e.g. "Linux") in the
--- stored array, so lowercasing alone would keep them and matching would still
--- fail. Completed jobs are never re-matched, so their labels are left as
--- historical data.
+-- Normalize the labels of all incomplete jobs (completed_at IS NULL) the same
+-- way ingestion does: lowercase and strip GitHub's implicit labels (self-hosted,
+-- linux). Already-assigned jobs are included on purpose -- disabling, deleting or
+-- updating a flavor resets its jobs to unassigned and re-runs assignment (see
+-- updateAssignedFlavorSql), which re-reads j.labels, so labels left in mixed case
+-- would re-introduce the casing mismatch for live jobs. The old case-sensitive
+-- strip also left uppercased implicit labels (e.g. "Linux") in the array, which
+-- lowercasing alone would keep. Completed jobs are never re-matched, so their
+-- labels are kept as historical data.
 UPDATE job AS j
 SET labels = COALESCE((
     SELECT array_agg(lower(x) ORDER BY ord)

--- a/internal/database/migrations/0002_lowercase_labels.up.sql
+++ b/internal/database/migrations/0002_lowercase_labels.up.sql
@@ -26,7 +26,12 @@ SET labels = COALESCE((
     FROM unnest(j.labels) WITH ORDINALITY AS u(x, ord)
     WHERE lower(x) NOT IN ('self-hosted', 'linux')
 ), '{}')
-WHERE j.completed_at IS NULL;
+WHERE j.completed_at IS NULL
+  -- Only touch rows that actually change: those with uppercase characters or a
+  -- still-present implicit label. Mirrors the flavor guard above and avoids
+  -- locking/WAL for jobs already in canonical form.
+  AND (j.labels::text <> lower(j.labels::text)
+       OR EXISTS (SELECT 1 FROM unnest(j.labels) AS x WHERE lower(x) IN ('self-hosted', 'linux')));
 
 -- Re-run flavor assignment for unassigned, incomplete jobs that now match a
 -- flavor after lowercasing. Mirrors the application's assignment query.

--- a/internal/database/migrations/0002_lowercase_labels.up.sql
+++ b/internal/database/migrations/0002_lowercase_labels.up.sql
@@ -14,15 +14,19 @@ SET labels = (
 )
 WHERE f.labels::text <> lower(f.labels::text);
 
--- Lowercase labels of jobs still needing a runner. Completed jobs are never
--- re-matched, so their labels are left as historical data.
+-- Normalize labels of jobs still needing a runner the same way ingestion does:
+-- lowercase and strip GitHub's implicit labels (self-hosted, linux). The old
+-- case-sensitive strip left uppercased implicit labels (e.g. "Linux") in the
+-- stored array, so lowercasing alone would keep them and matching would still
+-- fail. Completed jobs are never re-matched, so their labels are left as
+-- historical data.
 UPDATE job AS j
-SET labels = (
-    SELECT COALESCE(array_agg(lower(x) ORDER BY ord), '{}')
+SET labels = COALESCE((
+    SELECT array_agg(lower(x) ORDER BY ord)
     FROM unnest(j.labels) WITH ORDINALITY AS u(x, ord)
-)
-WHERE j.completed_at IS NULL
-  AND j.labels::text <> lower(j.labels::text);
+    WHERE lower(x) NOT IN ('self-hosted', 'linux')
+), '{}')
+WHERE j.completed_at IS NULL;
 
 -- Re-run flavor assignment for unassigned, incomplete jobs that now match a
 -- flavor after lowercasing. Mirrors the application's assignment query.

--- a/internal/database/migrations/0002_lowercase_labels.up.sql
+++ b/internal/database/migrations/0002_lowercase_labels.up.sql
@@ -1,0 +1,42 @@
+-- Copyright 2025 Canonical Ltd.
+-- See LICENSE file for licensing details.
+
+-- Flavor matching became case-insensitive: labels are now normalized to
+-- lowercase on insertion. Normalize existing rows so already-stored labels
+-- match, and re-run flavor assignment to recover jobs that were left unassigned
+-- only because of label casing (e.g. job "X64" vs flavor "x64").
+
+-- Lowercase all flavor labels (small table).
+UPDATE flavor AS f
+SET labels = (
+    SELECT COALESCE(array_agg(lower(x) ORDER BY ord), '{}')
+    FROM unnest(f.labels) WITH ORDINALITY AS u(x, ord)
+)
+WHERE f.labels::text <> lower(f.labels::text);
+
+-- Lowercase labels of jobs still needing a runner. Completed jobs are never
+-- re-matched, so their labels are left as historical data.
+UPDATE job AS j
+SET labels = (
+    SELECT COALESCE(array_agg(lower(x) ORDER BY ord), '{}')
+    FROM unnest(j.labels) WITH ORDINALITY AS u(x, ord)
+)
+WHERE j.completed_at IS NULL
+  AND j.labels::text <> lower(j.labels::text);
+
+-- Re-run flavor assignment for unassigned, incomplete jobs that now match a
+-- flavor after lowercasing. Mirrors the application's assignment query.
+UPDATE job AS j
+SET assigned_flavor = (SELECT f.name
+                       FROM flavor AS f
+                       WHERE f.is_disabled = FALSE
+                         AND f.platform = j.platform
+                         AND f.labels @> j.labels
+                       ORDER BY f.priority DESC, random()
+                       LIMIT 1)
+WHERE j.assigned_flavor IS NULL AND j.completed_at IS NULL
+  AND EXISTS (SELECT 1
+              FROM flavor AS f
+              WHERE f.is_disabled = FALSE
+                AND f.platform = j.platform
+                AND f.labels @> j.labels);

--- a/internal/planner/consumer.go
+++ b/internal/planner/consumer.go
@@ -201,9 +201,11 @@ func buildWebhookJob(jobEvent *github.WorkflowJobEvent, body []byte) (*githubWeb
 	}, nil
 }
 
+// isSelfHosted reports whether any label marks the job as self-hosted. The
+// check is case-insensitive since GitHub does not normalize label casing.
 func isSelfHosted(labels []string) bool {
 	for _, label := range labels {
-		if strings.Contains(label, "self-hosted") {
+		if strings.Contains(strings.ToLower(label), "self-hosted") {
 			return true
 		}
 	}

--- a/internal/planner/consumer_test.go
+++ b/internal/planner/consumer_test.go
@@ -710,6 +710,25 @@ func TestGetWorkflowJob(t *testing.T) {
 		}),
 		expectNil: true,
 	}, {
+		name: "self-hosted label with mixed casing is eligible",
+		headers: map[string]interface{}{
+			"X-GitHub-Event": "workflow_job",
+		},
+		body: mk(map[string]any{
+			"action": "queued",
+			"repository": map[string]any{
+				"full_name": "canonical/test-repo",
+			},
+			"workflow_job": map[string]any{
+				"id":         260,
+				"labels":     []string{"Self-Hosted", "X64", "Large"},
+				"created_at": "2025-01-01T10:00:00Z",
+			},
+		}),
+		validateJob: func(t *testing.T, job *githubWebhookJob) {
+			assert.Equal(t, "260", job.id)
+		},
+	}, {
 		name: "missing workflow_job field",
 		headers: map[string]interface{}{
 			"X-GitHub-Event": "workflow_job",


### PR DESCRIPTION
#### What this PR does

Makes planner flavor matching case-insensitive by storing labels in canonical lowercase:

- `stripDefaultLabels` lowercases job labels and strips GitHub's implicit labels case-insensitively (fixes a `Linux` strip hole).
- `AddFlavor` lowercases flavor labels on insert; `isSelfHosted` check is now case-insensitive.
- Migration `0002` lowercases existing flavor and incomplete-job labels and re-runs flavor assignment.

#### Why we need it

GitHub injects OS/arch labels with arbitrary casing (e.g. `X64`, `Linux`). Matching used case-sensitive Postgres array containment, so a job requesting `X64` never matched a flavor labelled `x64`. Those jobs ran (GitHub's own matching is case-insensitive) but contributed no pressure, so the autoscaler under-counted demand — a scaling-accuracy bug.

#### Test plan

TDD: failing unit + integration tests added first. Full `./internal/...` suite passes with `-tags=integration -race` against PostgreSQL 16.14; `gofmt`/`go vet` clean.

#### Review focus / breaking changes

Labels are normalized at the write boundary instead of in hot-path SQL, leaving matching queries and the GIN index unchanged. Flavor labels are now stored (and returned) lowercase — safe since GitHub matching is case-insensitive. Migration `0002` is forward-only; its down migration deliberately raises a clear error because the normalization is irreversible.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process — n/a
- [ ] Technical author has been assigned to review the PR in case of documentation changes — only a changelog entry
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration — n/a
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard — n/a
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors — n/a
- [ ] **If this PR involves Rockcraft:** I updated the version — n/a