### PR TITLE
feat(cmd): add waiting-p80-report CLI for daily P80 of job waiting time

### DIFF
--- a/.github/workflows/internal_tests.yaml
+++ b/.github/workflows/internal_tests.yaml
@@ -44,6 +44,12 @@ jobs:
           COVER_PKG=$(go list ./internal/... | grep -Ev "$EXCLUDE_PKGS" | tr '\n' ',')
           go test -v -count=1 -coverprofile=coverage.out -race -tags=integration -coverpkg=$COVER_PKG ./internal/...
 
+      - name: Test waiting-p80-report CLI
+        env:
+          POSTGRESQL_DB_CONNECT_STRING: postgres://postgres:postgres@localhost:5432/postgres
+        run: |
+          go test -v -count=1 -race -tags=integration ./cmd/waiting-p80-report/...
+
       - name: Print coverage report
         run: |
           go tool cover -func=coverage.out

--- a/cmd/waiting-p80-report/README.md
+++ b/cmd/waiting-p80-report/README.md
@@ -11,15 +11,19 @@ every day from history.
 
 ## Usage
 
-	waiting-p80-report -dsn "$POSTGRESQL_DB_CONNECT_STRING" -from 2026-05-01 -to 2026-05-31 -o p80.csv
+```shell
+waiting-p80-report -dsn "$POSTGRESQL_DB_CONNECT_STRING" -from 2026-05-01 -to 2026-05-31 -o p80.csv
+```
 
 Flags:
 
-	-dsn   PostgreSQL connection string (or POSTGRESQL_DB_CONNECT_STRING env)
-	-from  start date YYYY-MM-DD (inclusive, UTC)
-	-to    end date YYYY-MM-DD (inclusive, UTC); defaults to today UTC
-	-o     output CSV path (default: stdout)
-	-v     verbose logging to stderr
+```text
+-dsn   PostgreSQL connection string (or POSTGRESQL_DB_CONNECT_STRING env)
+-from  start date YYYY-MM-DD (inclusive, UTC)
+-to    end date YYYY-MM-DD (inclusive, UTC); defaults to today UTC
+-o     output CSV path (default: stdout)
+-v     verbose logging to stderr
+```
 
 CSV columns: `day,platform,p80_seconds,sample_count`.
 
@@ -33,7 +37,9 @@ the CSV.
 
 Daily at 06:00, appending yesterday's row to a running CSV:
 
-	0 6 * * *  waiting-p80-report -dsn "$DSN" -from $(date -d 'yesterday' +%F) -to $(date -d 'yesterday' +%F) >> /var/log/p80.csv
+```shell
+0 6 * * *  waiting-p80-report -dsn "$DSN" -from $(date -d 'yesterday' +%F) -to $(date -d 'yesterday' +%F) >> /var/log/p80.csv
+```
 
 ## Testing
 

--- a/cmd/waiting-p80-report/README.md
+++ b/cmd/waiting-p80-report/README.md
@@ -18,11 +18,12 @@ waiting-p80-report -dsn "$POSTGRESQL_DB_CONNECT_STRING" -from 2026-05-01 -to 202
 Flags:
 
 ```text
--dsn   PostgreSQL connection string (or POSTGRESQL_DB_CONNECT_STRING env)
--from  start date YYYY-MM-DD (inclusive, UTC)
--to    end date YYYY-MM-DD (inclusive, UTC); defaults to today UTC
--o     output CSV path (default: stdout)
--v     verbose logging to stderr
+-dsn        PostgreSQL connection string (or POSTGRESQL_DB_CONNECT_STRING env)
+-from       start date YYYY-MM-DD (inclusive, UTC)
+-to         end date YYYY-MM-DD (inclusive, UTC); defaults to today UTC
+-o          output CSV path (default: stdout)
+-v          verbose logging to stderr
+-no-header  omit CSV header line (useful for appending to an existing CSV)
 ```
 
 CSV columns: `day,platform,p80_seconds,sample_count`.
@@ -30,15 +31,17 @@ CSV columns: `day,platform,p80_seconds,sample_count`.
 The P80 is computed SQL-side via `percentile_cont(0.8) WITHIN GROUP (...)` grouped by the UTC
 day the job *started* (the moment waiting ended), matching the population the ephemeral
 `github_runner_planner_webhook_job_waiting_seconds` histogram records. Jobs with a NULL
-`started_at` or `created_at` are excluded. Days with no started jobs simply do not appear in
-the CSV.
+`started_at` or `created_at` are excluded, as are rows where `started_at < created_at`
+(negative waiting times) which would otherwise skew the percentile. Days with no started jobs
+simply do not appear in the CSV.
 
 ## Cron example
 
-Daily at 06:00, appending yesterday's row to a running CSV:
+Daily at 06:00, appending yesterday's row to a running CSV (use `-no-header` so the header
+is not repeated on each append):
 
 ```shell
-0 6 * * *  waiting-p80-report -dsn "$DSN" -from $(date -d 'yesterday' +%F) -to $(date -d 'yesterday' +%F) >> /var/log/p80.csv
+0 6 * * *  waiting-p80-report -dsn "$DSN" -no-header -from $(date -d 'yesterday' +%F) -to $(date -d 'yesterday' +%F) >> /var/log/p80.csv
 ```
 
 ## Testing

--- a/cmd/waiting-p80-report/README.md
+++ b/cmd/waiting-p80-report/README.md
@@ -1,0 +1,44 @@
+# waiting-p80-report
+
+Standalone CLI that extracts the daily P80 of GitHub runner job waiting time from the
+planner's PostgreSQL `job` table into a CSV. It is **not** part of the planner charm; no
+charm, migration, or metric change is required. Run it from cron, CI, or a laptop.
+
+The waiting time for each job is already stored durably as `started_at - created_at`
+(`internal/database/migrations/0001_init.up.sql`), and the `job` table has no TTL, so any past
+day's P80 can be recomputed on demand — point the tool at a date range and it recomputes
+every day from history.
+
+## Usage
+
+	waiting-p80-report -dsn "$POSTGRESQL_DB_CONNECT_STRING" -from 2026-05-01 -to 2026-05-31 -o p80.csv
+
+Flags:
+
+	-dsn   PostgreSQL connection string (or POSTGRESQL_DB_CONNECT_STRING env)
+	-from  start date YYYY-MM-DD (inclusive, UTC)
+	-to    end date YYYY-MM-DD (inclusive, UTC); defaults to today UTC
+	-o     output CSV path (default: stdout)
+	-v     verbose logging to stderr
+
+CSV columns: `day,platform,p80_seconds,sample_count`.
+
+The P80 is computed SQL-side via `percentile_cont(0.8) WITHIN GROUP (...)` grouped by the UTC
+day the job *started* (the moment waiting ended), matching the population the ephemeral
+`github_runner_planner_webhook_job_waiting_seconds` histogram records. Jobs with a NULL
+`started_at` or `created_at` are excluded. Days with no started jobs simply do not appear in
+the CSV.
+
+## Cron example
+
+Daily at 06:00, appending yesterday's row to a running CSV:
+
+	0 6 * * *  waiting-p80-report -dsn "$DSN" -from $(date -d 'yesterday' +%F) -to $(date -d 'yesterday' +%F) >> /var/log/p80.csv
+
+## Testing
+
+- Unit tests (no DB needed): `go test ./cmd/waiting-p80-report/...`
+- End-to-end test (requires Postgres): `go test -tags=integration ./cmd/waiting-p80-report/...`
+  with `POSTGRESQL_DB_CONNECT_STRING` set. The e2e test is `//go:build integration` tagged,
+  mirroring `internal/database/database_test.go`; CI runs it against a `postgres:16.14`
+  service container.

--- a/cmd/waiting-p80-report/e2e_test.go
+++ b/cmd/waiting-p80-report/e2e_test.go
@@ -109,6 +109,14 @@ func TestReport_EndToEnd(t *testing.T) {
 		"github", "null-started", day.Add(-999*time.Second))
 	require.NoError(t, err)
 
+	// Seed one job where started_at < created_at (negative wait) to confirm
+	// it is excluded by the started_at >= created_at guard.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO job (platform, id, created_at, started_at, raw)
+		VALUES ($1, $2, $3, $4, '{}')`,
+		"github", "negative-wait", day.Add(10*time.Second), day)
+	require.NoError(t, err)
+
 	cfg := config{
 		dsn:  isolatedDSN,
 		from: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
@@ -120,7 +128,7 @@ func TestReport_EndToEnd(t *testing.T) {
 	require.Len(t, rows, 2, "expected one row per day with started jobs")
 	assert.Equal(t, "2026-05-01", rows[0].Day.UTC().Format("2006-01-02"))
 	assert.Equal(t, "github", rows[0].Platform)
-	assert.Equal(t, 5, rows[0].SampleCount, "NULL-started job must be excluded")
+	assert.Equal(t, 5, rows[0].SampleCount, "NULL-started and negative-wait jobs must be excluded")
 	// P80 interpolates between 40 and 300 -> 92.
 	assert.InDelta(t, 92.0, rows[0].P80Seconds, 0.01)
 

--- a/cmd/waiting-p80-report/e2e_test.go
+++ b/cmd/waiting-p80-report/e2e_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -16,24 +17,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testSchema is a dedicated schema for e2e test isolation, so this test does not
+// mutate the shared public schema used by internal/database integration tests
+// when packages run in parallel.
+const testSchema = "waiting_p80_e2e"
+
+// withSearchPath returns a copy of dsn with search_path set to the given schema
+// via the libpq options parameter, so all connections from that DSN resolve
+// unqualified table names against the isolated schema.
+func withSearchPath(t *testing.T, dsn, schema string) string {
+	t.Helper()
+	u, err := url.Parse(dsn)
+	require.NoError(t, err)
+	q := u.Query()
+	q.Set("options", "-c search_path="+schema)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
 // TestReport_EndToEnd seeds jobs with known waiting times into a real Postgres
-// (POSTGRESQL_DB_CONNECT_STRING) and asserts the report query returns the
-// expected daily P80 and sample_count. Requires -tags=integration and a live DB,
-// mirroring the pattern in internal/database/database_test.go.
+// (POSTGRESQL_DB_CONNECT_STRING) using an isolated schema and asserts the
+// report query returns the expected daily P80 and sample_count. Requires
+// -tags=integration and a live DB, mirroring the pattern in
+// internal/database/database_test.go.
 func TestReport_EndToEnd(t *testing.T) {
 	dsn := os.Getenv("POSTGRESQL_DB_CONNECT_STRING")
 	if dsn == "" {
 		t.Fatal("test database not configured, missing POSTGRESQL_DB_CONNECT_STRING environment variable")
 	}
 
+	isolatedDSN := withSearchPath(t, dsn, testSchema)
+
 	ctx := t.Context()
-	pool, err := pgxpool.New(ctx, dsn)
+	pool, err := pgxpool.New(ctx, isolatedDSN)
 	require.NoError(t, err)
 	defer pool.Close()
 
-	// Reset and create the minimal schema the query needs.
+	// Create an isolated schema so this test does not clash with other
+	// integration test packages that reset the public schema.
+	_, err = pool.Exec(ctx, fmt.Sprintf(`
+		DROP SCHEMA IF EXISTS %s CASCADE;
+		CREATE SCHEMA %s;`, testSchema, testSchema))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", testSchema))
+	})
+
+	// Create the minimal table the query needs, inside the isolated schema.
 	_, err = pool.Exec(ctx, `
-		DROP TABLE IF EXISTS job;
 		CREATE TABLE job (
 			pk              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
 			platform        TEXT        NOT NULL,
@@ -79,7 +110,7 @@ func TestReport_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := config{
-		dsn:  dsn,
+		dsn:  isolatedDSN,
 		from: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
 		to:   time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC),
 	}

--- a/cmd/waiting-p80-report/e2e_test.go
+++ b/cmd/waiting-p80-report/e2e_test.go
@@ -128,11 +128,11 @@ func TestReport_EndToEnd(t *testing.T) {
 	require.Len(t, rows, 2, "expected one row per day with started jobs")
 	assert.Equal(t, "2026-05-01", rows[0].Day.UTC().Format("2006-01-02"))
 	assert.Equal(t, "github", rows[0].Platform)
-	assert.Equal(t, 5, rows[0].SampleCount, "NULL-started and negative-wait jobs must be excluded")
+	assert.Equal(t, int64(5), rows[0].SampleCount, "NULL-started and negative-wait jobs must be excluded")
 	// P80 interpolates between 40 and 300 -> 92.
 	assert.InDelta(t, 92.0, rows[0].P80Seconds, 0.01)
 
 	assert.Equal(t, "2026-05-02", rows[1].Day.UTC().Format("2006-01-02"))
-	assert.Equal(t, 1, rows[1].SampleCount)
+	assert.Equal(t, int64(1), rows[1].SampleCount)
 	assert.InDelta(t, 60.0, rows[1].P80Seconds, 0.01)
 }

--- a/cmd/waiting-p80-report/e2e_test.go
+++ b/cmd/waiting-p80-report/e2e_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+// Copyright 2026 Canonical Ltd.
+// See LICENSE file for licensing details.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReport_EndToEnd seeds jobs with known waiting times into a real Postgres
+// (POSTGRESQL_DB_CONNECT_STRING) and asserts the report query returns the
+// expected daily P80 and sample_count. Requires -tags=integration and a live DB,
+// mirroring the pattern in internal/database/database_test.go.
+func TestReport_EndToEnd(t *testing.T) {
+	dsn := os.Getenv("POSTGRESQL_DB_CONNECT_STRING")
+	if dsn == "" {
+		t.Fatal("test database not configured, missing POSTGRESQL_DB_CONNECT_STRING environment variable")
+	}
+
+	ctx := t.Context()
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// Reset and create the minimal schema the query needs.
+	_, err = pool.Exec(ctx, `
+		DROP TABLE IF EXISTS job;
+		CREATE TABLE job (
+			pk              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+			platform        TEXT        NOT NULL,
+			id              TEXT        NOT NULL,
+			labels          TEXT[]      NOT NULL DEFAULT '{}',
+			created_at      TIMESTAMPTZ NOT NULL,
+			started_at      TIMESTAMPTZ,
+			completed_at    TIMESTAMPTZ,
+			raw             JSONB       NOT NULL DEFAULT '{}',
+			assigned_flavor TEXT,
+			UNIQUE (platform, id),
+			CHECK (platform <> '' AND id <> '')
+		);`)
+	require.NoError(t, err)
+
+	// Seed 5 jobs on 2026-05-01 UTC with waiting times 10,20,30,40,300s.
+	// percentile_cont(0.8) over sorted [10,20,30,40,300]: position 0.8*(5-1)=3.2,
+	// interpolating between index 3 (40) and index 4 (300): 40 + 0.2*(300-40) = 92.
+	day := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	waits := []int{10, 20, 30, 40, 300}
+	for i, w := range waits {
+		created := day.Add(-time.Duration(w) * time.Second)
+		_, err = pool.Exec(ctx, `
+			INSERT INTO job (platform, id, created_at, started_at, raw)
+			VALUES ($1, $2, $3, $4, '{}')`,
+			"github", fmt.Sprintf("job-%d", i), created, day)
+		require.NoError(t, err)
+	}
+
+	// Seed one job on a different day to confirm grouping.
+	otherDay := time.Date(2026, 5, 2, 1, 0, 0, 0, time.UTC)
+	_, err = pool.Exec(ctx, `
+		INSERT INTO job (platform, id, created_at, started_at, raw)
+		VALUES ($1, $2, $3, $4, '{}')`,
+		"github", "other-day", otherDay.Add(-60*time.Second), otherDay)
+	require.NoError(t, err)
+
+	// Seed one job with NULL started_at to confirm it is excluded.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO job (platform, id, created_at, started_at, raw)
+		VALUES ($1, $2, $3, NULL, '{}')`,
+		"github", "null-started", day.Add(-999*time.Second))
+	require.NoError(t, err)
+
+	cfg := config{
+		dsn:  dsn,
+		from: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		to:   time.Date(2026, 5, 3, 0, 0, 0, 0, time.UTC),
+	}
+	rows, err := queryRows(ctx, cfg)
+	require.NoError(t, err)
+
+	require.Len(t, rows, 2, "expected one row per day with started jobs")
+	assert.Equal(t, "2026-05-01", rows[0].Day.UTC().Format("2006-01-02"))
+	assert.Equal(t, "github", rows[0].Platform)
+	assert.Equal(t, 5, rows[0].SampleCount, "NULL-started job must be excluded")
+	// P80 interpolates between 40 and 300 -> 92.
+	assert.InDelta(t, 92.0, rows[0].P80Seconds, 0.01)
+
+	assert.Equal(t, "2026-05-02", rows[1].Day.UTC().Format("2006-01-02"))
+	assert.Equal(t, 1, rows[1].SampleCount)
+	assert.InDelta(t, 60.0, rows[1].P80Seconds, 0.01)
+}

--- a/cmd/waiting-p80-report/main.go
+++ b/cmd/waiting-p80-report/main.go
@@ -123,6 +123,7 @@ func buildQuery() string {
 		FROM job
 		WHERE started_at IS NOT NULL
 		  AND created_at IS NOT NULL
+		  AND started_at >= created_at
 		  AND started_at >= @from
 		  AND started_at < @to
 		GROUP BY day, platform

--- a/cmd/waiting-p80-report/main.go
+++ b/cmd/waiting-p80-report/main.go
@@ -25,11 +25,12 @@ import (
 )
 
 type config struct {
-	dsn     string
-	from    time.Time
-	to      time.Time
-	out     string
-	verbose bool
+	dsn      string
+	from     time.Time
+	to       time.Time
+	out      string
+	verbose  bool
+	noHeader bool
 }
 
 func parseConfig() (config, error) {
@@ -39,6 +40,7 @@ func parseConfig() (config, error) {
 	fromStr := flag.String("from", "", "start date YYYY-MM-DD (inclusive, UTC)")
 	toStr := flag.String("to", "", "end date YYYY-MM-DD (inclusive, UTC); defaults to today UTC")
 	flag.BoolVar(&cfg.verbose, "v", false, "verbose logging to stderr")
+	flag.BoolVar(&cfg.noHeader, "no-header", false, "omit CSV header line (useful for appending to an existing CSV)")
 	flag.Parse()
 
 	if cfg.dsn == "" {
@@ -103,7 +105,7 @@ func run(cfg config) error {
 		defer f.Close()
 		w = f
 	}
-	return writeCSV(w, rows)
+	return writeCSV(w, rows, cfg.noHeader)
 }
 
 // dailyP80Row is one row of the daily P80 rollup.
@@ -157,14 +159,17 @@ func queryRows(ctx context.Context, cfg config) ([]dailyP80Row, error) {
 	return out, rows.Err()
 }
 
-// writeCSV writes the daily P80 rows as CSV with a header line. Days with no jobs
-// do not appear in rows (the SQL GROUP BY omits them), so absent days are simply
-// absent from the CSV. Flush errors (e.g. disk full, broken pipe) are surfaced
-// via csv.Writer.Error rather than silently dropped.
-func writeCSV(w io.Writer, rows []dailyP80Row) error {
+// writeCSV writes the daily P80 rows as CSV. When noHeader is false (default) a
+// header line is emitted; set noHeader to true for append use-cases (e.g. cron).
+// Days with no jobs do not appear in rows (the SQL GROUP BY omits them), so
+// absent days are simply absent from the CSV. Flush errors (e.g. disk full,
+// broken pipe) are surfaced via csv.Writer.Error rather than silently dropped.
+func writeCSV(w io.Writer, rows []dailyP80Row, noHeader bool) error {
 	cw := csv.NewWriter(w)
-	if err := cw.Write([]string{"day", "platform", "p80_seconds", "sample_count"}); err != nil {
-		return err
+	if !noHeader {
+		if err := cw.Write([]string{"day", "platform", "p80_seconds", "sample_count"}); err != nil {
+			return err
+		}
 	}
 	for _, r := range rows {
 		if err := cw.Write([]string{

--- a/cmd/waiting-p80-report/main.go
+++ b/cmd/waiting-p80-report/main.go
@@ -37,7 +37,7 @@ func parseConfig() (config, error) {
 	flag.StringVar(&cfg.dsn, "dsn", "", "PostgreSQL connection string (or set POSTGRESQL_DB_CONNECT_STRING)")
 	flag.StringVar(&cfg.out, "o", "", "output CSV path (default: stdout)")
 	fromStr := flag.String("from", "", "start date YYYY-MM-DD (inclusive, UTC)")
-	toStr := flag.String("to", "", "end date YYYY-MM-DD (inclusive, UTC); defaults to today UTC)")
+	toStr := flag.String("to", "", "end date YYYY-MM-DD (inclusive, UTC); defaults to today UTC")
 	flag.BoolVar(&cfg.verbose, "v", false, "verbose logging to stderr")
 	flag.Parse()
 
@@ -113,7 +113,7 @@ type dailyP80Row struct {
 
 func buildQuery() string {
 	return `
-		SELECT date_trunc('day', started_at AT TIME ZONE 'UTC') AS day,
+		SELECT date_trunc('day', started_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS day,
 		       platform,
 		       percentile_cont(0.8) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (started_at - created_at))) AS p80_seconds,
 		       COUNT(*) AS sample_count
@@ -155,10 +155,10 @@ func queryRows(ctx context.Context, cfg config) ([]dailyP80Row, error) {
 
 // writeCSV writes the daily P80 rows as CSV with a header line. Days with no jobs
 // do not appear in rows (the SQL GROUP BY omits them), so absent days are simply
-// absent from the CSV.
+// absent from the CSV. Flush errors (e.g. disk full, broken pipe) are surfaced
+// via csv.Writer.Error rather than silently dropped.
 func writeCSV(w io.Writer, rows []dailyP80Row) error {
 	cw := csv.NewWriter(w)
-	defer cw.Flush()
 	if err := cw.Write([]string{"day", "platform", "p80_seconds", "sample_count"}); err != nil {
 		return err
 	}
@@ -172,5 +172,6 @@ func writeCSV(w io.Writer, rows []dailyP80Row) error {
 			return err
 		}
 	}
-	return nil
+	cw.Flush()
+	return cw.Error()
 }

--- a/cmd/waiting-p80-report/main.go
+++ b/cmd/waiting-p80-report/main.go
@@ -111,7 +111,7 @@ type dailyP80Row struct {
 	Day         time.Time
 	Platform    string
 	P80Seconds  float64
-	SampleCount int
+	SampleCount int64
 }
 
 func buildQuery() string {
@@ -171,7 +171,7 @@ func writeCSV(w io.Writer, rows []dailyP80Row) error {
 			r.Day.UTC().Format("2006-01-02"),
 			r.Platform,
 			strconv.FormatFloat(r.P80Seconds, 'f', -1, 64),
-			strconv.Itoa(r.SampleCount),
+			strconv.FormatInt(r.SampleCount, 10),
 		}); err != nil {
 			return err
 		}

--- a/cmd/waiting-p80-report/main.go
+++ b/cmd/waiting-p80-report/main.go
@@ -91,6 +91,9 @@ func run(cfg config) error {
 	if err != nil {
 		return err
 	}
+	if cfg.verbose {
+		fmt.Fprintf(os.Stderr, "retrieved %d rows\n", len(rows))
+	}
 	var w io.Writer = os.Stdout
 	if cfg.out != "" {
 		f, err := os.Create(cfg.out)

--- a/cmd/waiting-p80-report/main.go
+++ b/cmd/waiting-p80-report/main.go
@@ -1,0 +1,176 @@
+// Package main is a standalone CLI that extracts the daily P80 of GitHub runner
+// job waiting time from the planner's PostgreSQL database into a CSV.
+//
+// It is not part of the planner charm. Run it ad hoc, from cron, or in CI. It
+// reads the planner's `job` table read-only.
+//
+// Usage:
+//
+//	waiting-p80-report -dsn "$POSTGRESQL_DB_CONNECT_STRING" \
+//	    -from 2026-05-01 -to 2026-05-31 -o p80.csv
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type config struct {
+	dsn     string
+	from    time.Time
+	to      time.Time
+	out     string
+	verbose bool
+}
+
+func parseConfig() (config, error) {
+	cfg := config{}
+	flag.StringVar(&cfg.dsn, "dsn", "", "PostgreSQL connection string (or set POSTGRESQL_DB_CONNECT_STRING)")
+	flag.StringVar(&cfg.out, "o", "", "output CSV path (default: stdout)")
+	fromStr := flag.String("from", "", "start date YYYY-MM-DD (inclusive, UTC)")
+	toStr := flag.String("to", "", "end date YYYY-MM-DD (inclusive, UTC); defaults to today UTC)")
+	flag.BoolVar(&cfg.verbose, "v", false, "verbose logging to stderr")
+	flag.Parse()
+
+	if cfg.dsn == "" {
+		cfg.dsn = os.Getenv("POSTGRESQL_DB_CONNECT_STRING")
+	}
+	if cfg.dsn == "" {
+		return cfg, fmt.Errorf("missing -dsn or POSTGRESQL_DB_CONNECT_STRING")
+	}
+
+	if *fromStr == "" {
+		return cfg, fmt.Errorf("missing -from (YYYY-MM-DD)")
+	}
+	var err error
+	cfg.from, err = time.Parse("2006-01-02", *fromStr)
+	if err != nil {
+		return cfg, fmt.Errorf("invalid -from: %w", err)
+	}
+	if *toStr == "" {
+		cfg.to = time.Now().UTC().Truncate(24 * time.Hour)
+	} else {
+		cfg.to, err = time.Parse("2006-01-02", *toStr)
+		if err != nil {
+			return cfg, fmt.Errorf("invalid -to: %w", err)
+		}
+	}
+	// -to is inclusive; bump to end of the day for SQL half-open range.
+	cfg.to = cfg.to.Add(24 * time.Hour)
+	if !cfg.to.After(cfg.from) {
+		return cfg, fmt.Errorf("-to must be after -from")
+	}
+	return cfg, nil
+}
+
+func main() {
+	cfg, err := parseConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		flag.Usage()
+		os.Exit(2)
+	}
+	if err := run(cfg); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run(cfg config) error {
+	ctx := context.Background()
+	rows, err := queryRows(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	var w io.Writer = os.Stdout
+	if cfg.out != "" {
+		f, err := os.Create(cfg.out)
+		if err != nil {
+			return fmt.Errorf("open output: %w", err)
+		}
+		defer f.Close()
+		w = f
+	}
+	return writeCSV(w, rows)
+}
+
+// dailyP80Row is one row of the daily P80 rollup.
+type dailyP80Row struct {
+	Day         time.Time
+	Platform    string
+	P80Seconds  float64
+	SampleCount int
+}
+
+func buildQuery() string {
+	return `
+		SELECT date_trunc('day', started_at AT TIME ZONE 'UTC') AS day,
+		       platform,
+		       percentile_cont(0.8) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (started_at - created_at))) AS p80_seconds,
+		       COUNT(*) AS sample_count
+		FROM job
+		WHERE started_at IS NOT NULL
+		  AND created_at IS NOT NULL
+		  AND started_at >= @from
+		  AND started_at < @to
+		GROUP BY day, platform
+		ORDER BY day, platform`
+}
+
+func queryRows(ctx context.Context, cfg config) ([]dailyP80Row, error) {
+	pool, err := pgxpool.New(ctx, cfg.dsn)
+	if err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	defer pool.Close()
+
+	rows, err := pool.Query(ctx, buildQuery(), pgx.NamedArgs{
+		"from": cfg.from.UTC(),
+		"to":   cfg.to.UTC(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []dailyP80Row
+	for rows.Next() {
+		var r dailyP80Row
+		if err := rows.Scan(&r.Day, &r.Platform, &r.P80Seconds, &r.SampleCount); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// writeCSV writes the daily P80 rows as CSV with a header line. Days with no jobs
+// do not appear in rows (the SQL GROUP BY omits them), so absent days are simply
+// absent from the CSV.
+func writeCSV(w io.Writer, rows []dailyP80Row) error {
+	cw := csv.NewWriter(w)
+	defer cw.Flush()
+	if err := cw.Write([]string{"day", "platform", "p80_seconds", "sample_count"}); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		if err := cw.Write([]string{
+			r.Day.UTC().Format("2006-01-02"),
+			r.Platform,
+			strconv.FormatFloat(r.P80Seconds, 'f', -1, 64),
+			strconv.Itoa(r.SampleCount),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/waiting-p80-report/main_test.go
+++ b/cmd/waiting-p80-report/main_test.go
@@ -35,7 +35,7 @@ func TestWriteCSV(t *testing.T) {
 		{Day: time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC), Platform: "github", P80Seconds: 0, SampleCount: 0},
 	}
 	var buf bytes.Buffer
-	if err := writeCSV(&buf, rows); err != nil {
+	if err := writeCSV(&buf, rows, false); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -45,9 +45,24 @@ func TestWriteCSV(t *testing.T) {
 	}
 }
 
+func TestWriteCSV_NoHeader(t *testing.T) {
+	rows := []dailyP80Row{
+		{Day: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), Platform: "github", P80Seconds: 210.5, SampleCount: 42},
+	}
+	var buf bytes.Buffer
+	if err := writeCSV(&buf, rows, true); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	want := "2026-05-01,github,210.5,42\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
 func TestWriteCSV_Empty(t *testing.T) {
 	var buf bytes.Buffer
-	if err := writeCSV(&buf, nil); err != nil {
+	if err := writeCSV(&buf, nil, false); err != nil {
 		t.Fatal(err)
 	}
 	want := "day,platform,p80_seconds,sample_count\n"

--- a/cmd/waiting-p80-report/main_test.go
+++ b/cmd/waiting-p80-report/main_test.go
@@ -16,6 +16,7 @@ func TestBuildQuery(t *testing.T) {
 		{"percentile_cont(0.8)", "percentile_cont(0.8)"},
 		{"started_at guard", "started_at IS NOT NULL"},
 		{"created_at guard", "created_at IS NOT NULL"},
+		{"non-negative wait guard", "started_at >= created_at"},
 		{"day bucket", "date_trunc('day', started_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'"},
 		{"group by day", "GROUP BY day, platform"},
 		{"from param", "@from"},

--- a/cmd/waiting-p80-report/main_test.go
+++ b/cmd/waiting-p80-report/main_test.go
@@ -16,7 +16,7 @@ func TestBuildQuery(t *testing.T) {
 		{"percentile_cont(0.8)", "percentile_cont(0.8)"},
 		{"started_at guard", "started_at IS NOT NULL"},
 		{"created_at guard", "created_at IS NOT NULL"},
-		{"day bucket", "date_trunc('day', started_at AT TIME ZONE 'UTC')"},
+		{"day bucket", "date_trunc('day', started_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'"},
 		{"group by day", "GROUP BY day, platform"},
 		{"from param", "@from"},
 		{"to param", "@to"},

--- a/cmd/waiting-p80-report/main_test.go
+++ b/cmd/waiting-p80-report/main_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Canonical Ltd.
+// See LICENSE file for licensing details.
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildQuery(t *testing.T) {
+	q := buildQuery()
+	checks := []struct{ name, want string }{
+		{"percentile_cont(0.8)", "percentile_cont(0.8)"},
+		{"started_at guard", "started_at IS NOT NULL"},
+		{"created_at guard", "created_at IS NOT NULL"},
+		{"day bucket", "date_trunc('day', started_at AT TIME ZONE 'UTC')"},
+		{"group by day", "GROUP BY day, platform"},
+		{"from param", "@from"},
+		{"to param", "@to"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(q, c.want) {
+			t.Fatalf("%s: query missing %q\nquery:\n%s", c.name, c.want, q)
+		}
+	}
+}
+
+func TestWriteCSV(t *testing.T) {
+	rows := []dailyP80Row{
+		{Day: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), Platform: "github", P80Seconds: 210.5, SampleCount: 42},
+		{Day: time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC), Platform: "github", P80Seconds: 0, SampleCount: 0},
+	}
+	var buf bytes.Buffer
+	if err := writeCSV(&buf, rows); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	want := "day,platform,p80_seconds,sample_count\n2026-05-01,github,210.5,42\n2026-05-02,github,0,0\n"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestWriteCSV_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeCSV(&buf, nil); err != nil {
+		t.Fatal(err)
+	}
+	want := "day,platform,p80_seconds,sample_count\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-19
+
+- add `waiting-p80-report` standalone CLI that extracts the daily P80 of job waiting time from the planner PostgreSQL database into a CSV. Not part of the planner charm; no charm or migration change.
+
 ## 2026-06-18
 
 - match planner runner labels case-insensitively, so jobs requesting GitHub's implicit label casing (e.g. `X64`, `Linux`) match flavors defined in lowercase. A migration converts existing labels to lowercase and reassigns jobs previously left unmatched due to casing.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-06-19
 
-- add `waiting-p80-report` standalone CLI that extracts the daily P80 of job waiting time from the planner PostgreSQL database into a CSV. Not part of the planner charm; no charm or migration change.
+- add `waiting-p80-report` standalone CLI that extracts the daily P80 of job waiting time from the planner's PostgreSQL database into a CSV. Not part of the planner charm; no charm or migration change.
 
 ## 2026-06-18
 


### PR DESCRIPTION
#### What this PR does

Adds `cmd/waiting-p80-report`, a standalone CLI that extracts the daily P80 of job waiting time from the planner's PostgreSQL `job` table into a CSV. Not part of the planner charm — no charm, migration, or metric changes.

#### Why we need it

The waiting time for every job is already durably stored as `started_at - created_at`, but the existing Prometheus histogram is ephemeral and retention-bound. This tool recomputes the daily P80 on demand from the source of truth, for ad-hoc, cron, or CI reporting.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g., changes to the way tests are run)
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [x] **If integration test modules are used:** I updated the workflow configuration
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR involves Rockcraft:** I updated the version
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md`
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked whether the `AGENTS.md` "12-factor divergences" guidance still matches the upstream copilot-collections guidance

## Test plan

- `go build ./... && go vet ./...` — clean
- `go test ./cmd/waiting-p80-report/...` — unit tests pass (no DB needed)
- `go test -tags=integration ./cmd/waiting-p80-report/...` with `POSTGRESQL_DB_CONNECT_STRING` — e2e test passes against a real Postgres 16 (seeds jobs with known waiting times, asserts P80 via `percentile_cont`, confirms NULL-started exclusion and per-day grouping)
- `go test -tags=integration ./internal/...` — existing internal packages still pass
- `scripts/check_agents_md.py` — citations OK (no AGENTS.md change)

## Review focus

- The P80 is computed SQL-side via `percentile_cont(0.8) WITHIN GROUP (...)` grouped by UTC day the job *started*, matching the population the ephemeral histogram records (`internal/planner/telemetry.go` `ObserveConsumedGitHubWebhook`). Confirm the bucketing-by-started-at and NULL-exclusion match that intent.
- The e2e test is `//go:build integration` tagged, gated on `POSTGRESQL_DB_CONNECT_STRING`, mirroring `internal/database/database_test.go`.
- CI step added to `.github/workflows/internal_tests.yaml` reusing the existing `postgres:16.14` service container.

## Potential breaking changes

None. New standalone command; no changes to `internal/`, charms, or migrations.

## New dependencies, APIs, modules, or workflow changes

- New Go binary under `cmd/waiting-p80-report` (uses `pgx/v5`, already in `go.mod` — no new dependency).
- New CI step in `internal_tests.yaml`.
