### PR TITLE
fix(cmd): clamp negative waiting times to zero instead of excluding

### DIFF
--- a/cmd/waiting-p80-report/README.md
+++ b/cmd/waiting-p80-report/README.md
@@ -31,9 +31,11 @@ CSV columns: `day,platform,p80_seconds,sample_count`.
 The P80 is computed SQL-side via `percentile_cont(0.8) WITHIN GROUP (...)` grouped by the UTC
 day the job *started* (the moment waiting ended), matching the population the ephemeral
 `github_runner_planner_webhook_job_waiting_seconds` histogram records. Jobs with a NULL
-`started_at` or `created_at` are excluded, as are rows where `started_at < created_at`
-(negative waiting times) which would otherwise skew the percentile. Days with no started jobs
-simply do not appear in the CSV.
+`started_at` or `created_at` are excluded. Rows where `started_at < created_at` (negative
+waiting times from clock skew, for jobs that effectively started immediately) are clamped to
+0 rather than dropped — keeping them in the population avoids biasing the percentile upward
+and matches how the histogram buckets them. Days with no started jobs simply do not appear in
+the CSV.
 
 ## Cron example
 

--- a/cmd/waiting-p80-report/e2e_test.go
+++ b/cmd/waiting-p80-report/e2e_test.go
@@ -109,8 +109,8 @@ func TestReport_EndToEnd(t *testing.T) {
 		"github", "null-started", day.Add(-999*time.Second))
 	require.NoError(t, err)
 
-	// Seed one job where started_at < created_at (negative wait) to confirm
-	// it is excluded by the started_at >= created_at guard.
+	// Seed one job where started_at < created_at (negative wait, -10s) to
+	// confirm it is clamped to 0 and kept in the population, not excluded.
 	_, err = pool.Exec(ctx, `
 		INSERT INTO job (platform, id, created_at, started_at, raw)
 		VALUES ($1, $2, $3, $4, '{}')`,
@@ -128,9 +128,11 @@ func TestReport_EndToEnd(t *testing.T) {
 	require.Len(t, rows, 2, "expected one row per day with started jobs")
 	assert.Equal(t, "2026-05-01", rows[0].Day.UTC().Format("2006-01-02"))
 	assert.Equal(t, "github", rows[0].Platform)
-	assert.Equal(t, int64(5), rows[0].SampleCount, "NULL-started and negative-wait jobs must be excluded")
-	// P80 interpolates between 40 and 300 -> 92.
-	assert.InDelta(t, 92.0, rows[0].P80Seconds, 0.01)
+	assert.Equal(t, int64(6), rows[0].SampleCount, "NULL-started excluded; negative-wait clamped to 0 and kept")
+	// The negative-wait job is clamped to 0, so the day-1 population is sorted
+	// [0,10,20,30,40,300] (n=6). percentile_cont(0.8) position 0.8*(6-1)=4.0
+	// lands exactly on index 4 -> 40.
+	assert.InDelta(t, 40.0, rows[0].P80Seconds, 0.01)
 
 	assert.Equal(t, "2026-05-02", rows[1].Day.UTC().Format("2006-01-02"))
 	assert.Equal(t, int64(1), rows[1].SampleCount)

--- a/cmd/waiting-p80-report/main.go
+++ b/cmd/waiting-p80-report/main.go
@@ -120,12 +120,11 @@ func buildQuery() string {
 	return `
 		SELECT date_trunc('day', started_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS day,
 		       platform,
-		       percentile_cont(0.8) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (started_at - created_at))) AS p80_seconds,
+		       percentile_cont(0.8) WITHIN GROUP (ORDER BY GREATEST(EXTRACT(EPOCH FROM (started_at - created_at)), 0)) AS p80_seconds,
 		       COUNT(*) AS sample_count
 		FROM job
 		WHERE started_at IS NOT NULL
 		  AND created_at IS NOT NULL
-		  AND started_at >= created_at
 		  AND started_at >= @from
 		  AND started_at < @to
 		GROUP BY day, platform

--- a/cmd/waiting-p80-report/main_test.go
+++ b/cmd/waiting-p80-report/main_test.go
@@ -16,7 +16,7 @@ func TestBuildQuery(t *testing.T) {
 		{"percentile_cont(0.8)", "percentile_cont(0.8)"},
 		{"started_at guard", "started_at IS NOT NULL"},
 		{"created_at guard", "created_at IS NOT NULL"},
-		{"non-negative wait guard", "started_at >= created_at"},
+		{"negative wait clamped to zero", "GREATEST(EXTRACT(EPOCH FROM (started_at - created_at)), 0)"},
 		{"day bucket", "date_trunc('day', started_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'"},
 		{"group by day", "GROUP BY day, platform"},
 		{"from param", "@from"},
@@ -26,6 +26,11 @@ func TestBuildQuery(t *testing.T) {
 		if !strings.Contains(q, c.want) {
 			t.Fatalf("%s: query missing %q\nquery:\n%s", c.name, c.want, q)
 		}
+	}
+	// Negative waits are clamped to 0, not filtered out, so the row-dropping
+	// guard must be gone — otherwise fast jobs would be excluded and P80 skewed up.
+	if strings.Contains(q, "started_at >= created_at") {
+		t.Fatalf("query must not exclude negative waits; clamp to 0 instead\nquery:\n%s", q)
 	}
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-22
+
+- `waiting-p80-report`: clamp negative waiting times (clock skew, `started_at < created_at`) to 0 instead of excluding those jobs. Previously dropping them removed the fastest jobs from the population and biased the reported P80 upward.
+
 ## 2026-06-19
 
 - add `waiting-p80-report` standalone CLI that extracts the daily P80 of job waiting time from the planner's PostgreSQL database into a CSV. Not part of the planner charm; no charm or migration change.


### PR DESCRIPTION
#### What this PR does

Changes `waiting-p80-report` to **clamp** negative waiting times (`started_at < created_at`) to 0 rather than excluding those rows. The percentile now orders by `GREATEST(EXTRACT(EPOCH FROM (started_at - created_at)), 0)` and the row-dropping `started_at >= created_at` guard is removed (NULL guards stay).

#### Why we need it

Negative waits are clock-skew artifacts for jobs that effectively started immediately (true wait ~0s). Dropping them removed the fastest jobs from the percentile population and biased P80 **upward** — on a sampled day, ~12% of jobs were negative and excluding them moved P80 from 1323s to 1628s (~19%). Clamping keeps them as ~0s waits, which also matches how the `github_runner_planner_webhook_job_waiting_seconds` histogram buckets negatives (into its `le=0` bucket), restoring the "same population" property the report documents.

#### Test plan

- Unit: `go test ./cmd/waiting-p80-report/...` — `TestBuildQuery` updated to require the `GREATEST(..., 0)` clamp and assert the old guard is gone.
- Integration (`-tags=integration`, live Postgres): `TestReport_EndToEnd` — the seeded negative-wait job is now clamped to 0 and kept (sample_count 5→6, day-1 P80 92→40).
- `go build`, `go vet`, `gofmt` clean.

#### Review focus

- The semantic choice: clamp-to-zero vs. drop-the-row. Clamp is unbiased and matches the histogram; drop biased P80 up. A pathologically large negative still clamps to 0 (harmless for a percentile), so no upper bound on negativity is applied.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — n/a, no process change
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — README/changelog wording only
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration — n/a, existing e2e test, no module change
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard — n/a
- [ ] **If this PR involves Terraform** — n/a
- [ ] **If this PR involves Rockcraft** — n/a
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md` — n/a, standalone CLI
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`** — n/a