### PR TITLE
fix(cmd): count only owned jobs in waiting-p80-report

### DIFF
--- a/cmd/waiting-p80-report/README.md
+++ b/cmd/waiting-p80-report/README.md
@@ -37,6 +37,19 @@ waiting times from clock skew, for jobs that effectively started immediately) ar
 and matches how the histogram buckets them. Days with no started jobs simply do not appear in
 the CSV.
 
+Only jobs **we own** are counted: the query filters on `assigned_flavor IS NOT NULL`, which is
+set exactly when a job's labels matched one of our configured flavors. Jobs served by runners we
+don't manage (e.g. third-party self-hosted runners on repositories we ingest webhooks from, such
+as `spread-enabled`) never match a flavor and are excluded so they don't skew the P80.
+
+> **Caveat — data before 2026-06-19.** Case-insensitive label matching landed that day
+> (`fix(planner): match runner labels case-insensitively`, #243). Its migration re-ran flavor
+> assignment only for *in-progress* jobs; **completed** jobs that we owned but that missed
+> assignment due to label casing (e.g. job `X64` vs flavor `x64`) were left at
+> `assigned_flavor = NULL` and never backfilled. For day ranges before 2026-06-19 those jobs are
+> therefore excluded, so `sample_count` undercounts and the P80 may be skewed. Reports over
+> ranges from 2026-06-19 onward are unaffected.
+
 ## Cron example
 
 Daily at 06:00, appending yesterday's row to a running CSV (use `-no-header` so the header

--- a/cmd/waiting-p80-report/README.md
+++ b/cmd/waiting-p80-report/README.md
@@ -42,13 +42,13 @@ set when a job's labels match one of our configured flavors. Jobs served by runn
 don't manage (for example, third-party self-hosted runners on repositories we ingest webhooks
 from, such as `spread-enabled`) never match a flavor and are excluded so they don't skew the P80.
 
-> **Caveat — data before 2026-06-19.** Case-insensitive label matching landed that day
-> (`fix(planner): match runner labels case-insensitively`, #243). Its migration re-ran flavor
-> assignment only for *in-progress* jobs; **completed** jobs that we owned but that missed
-> assignment due to label casing (for example, job label `X64` not matching flavor `x64`) were left at
-> `assigned_flavor = NULL` and never backfilled. For day ranges before 2026-06-19 those jobs are
-> therefore excluded, so `sample_count` undercounts and the P80 may be skewed. Reports over
-> ranges from 2026-06-19 onward are unaffected.
+> **Caveat — data before 2026-06-18.** Case-insensitive label matching landed then
+> (`fix(planner): match runner labels case-insensitively`, #243; see the 2026-06-18 changelog
+> entry). Its migration re-ran flavor assignment only for *in-progress* jobs; **completed** jobs
+> that we owned but that missed assignment due to label casing (for example, job label `X64` not
+> matching flavor `x64`) were left at `assigned_flavor = NULL` and never backfilled. For day
+> ranges before 2026-06-18 those jobs are therefore excluded, so `sample_count` undercounts and
+> the P80 may be skewed. Reports over ranges from 2026-06-18 onward are unaffected.
 
 ## Cron example
 

--- a/cmd/waiting-p80-report/README.md
+++ b/cmd/waiting-p80-report/README.md
@@ -38,14 +38,14 @@ and matches how the histogram buckets them. Days with no started jobs simply do 
 the CSV.
 
 Only jobs **we own** are counted: the query filters on `assigned_flavor IS NOT NULL`, which is
-set exactly when a job's labels matched one of our configured flavors. Jobs served by runners we
-don't manage (e.g. third-party self-hosted runners on repositories we ingest webhooks from, such
-as `spread-enabled`) never match a flavor and are excluded so they don't skew the P80.
+set when a job's labels match one of our configured flavors. Jobs served by runners we
+don't manage (for example, third-party self-hosted runners on repositories we ingest webhooks
+from, such as `spread-enabled`) never match a flavor and are excluded so they don't skew the P80.
 
 > **Caveat — data before 2026-06-19.** Case-insensitive label matching landed that day
 > (`fix(planner): match runner labels case-insensitively`, #243). Its migration re-ran flavor
 > assignment only for *in-progress* jobs; **completed** jobs that we owned but that missed
-> assignment due to label casing (e.g. job `X64` vs flavor `x64`) were left at
+> assignment due to label casing (for example, job label `X64` not matching flavor `x64`) were left at
 > `assigned_flavor = NULL` and never backfilled. For day ranges before 2026-06-19 those jobs are
 > therefore excluded, so `sample_count` undercounts and the P80 may be skewed. Reports over
 > ranges from 2026-06-19 onward are unaffected.

--- a/cmd/waiting-p80-report/README.md
+++ b/cmd/waiting-p80-report/README.md
@@ -47,8 +47,8 @@ from, such as `spread-enabled`) never match a flavor and are excluded so they do
 > entry). Its migration re-ran flavor assignment only for *in-progress* jobs; **completed** jobs
 > that we owned but that missed assignment due to label casing (for example, job label `X64` not
 > matching flavor `x64`) were left at `assigned_flavor = NULL` and never backfilled. For day
-> ranges before 2026-06-18 those jobs are therefore excluded, so `sample_count` undercounts and
-> the P80 may be skewed. Reports over ranges from 2026-06-18 onward are unaffected.
+> ranges before 2026-06-18 those jobs are therefore excluded, so `sample_count` is lower than the
+> true total and the P80 may be skewed. Reports over ranges from 2026-06-18 onward are unaffected.
 
 ## Cron example
 

--- a/cmd/waiting-p80-report/e2e_test.go
+++ b/cmd/waiting-p80-report/e2e_test.go
@@ -80,11 +80,12 @@ func TestReport_EndToEnd(t *testing.T) {
 		);`)
 	require.NoError(t, err)
 
-	// Seed 5 jobs on 2026-05-01 UTC with waiting times 10,20,30,40,300s.
-	// percentile_cont(0.8) over sorted [10,20,30,40,300]: position 0.8*(5-1)=3.2,
-	// interpolating between index 3 (40) and index 4 (300): 40 + 0.2*(300-40) = 92.
-	// All counted jobs carry an assigned_flavor: the report counts only jobs we
-	// own, i.e. those whose labels matched one of our flavors.
+	// Seed 5 owned jobs on 2026-05-01 UTC with waiting times 10,20,30,40,300s.
+	// Each carries an assigned_flavor because the report counts only jobs we
+	// own (those whose labels matched one of our flavors). Over these 5 alone,
+	// percentile_cont(0.8) of sorted [10,20,30,40,300] is 40 + 0.2*(300-40) = 92
+	// (position 0.8*(5-1)=3.2). A negative-wait job seeded below joins this day's
+	// population, so the asserted day-1 P80 is 40, not 92 — see the assertion.
 	day := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	waits := []int{10, 20, 30, 40, 300}
 	for i, w := range waits {

--- a/cmd/waiting-p80-report/e2e_test.go
+++ b/cmd/waiting-p80-report/e2e_test.go
@@ -83,13 +83,15 @@ func TestReport_EndToEnd(t *testing.T) {
 	// Seed 5 jobs on 2026-05-01 UTC with waiting times 10,20,30,40,300s.
 	// percentile_cont(0.8) over sorted [10,20,30,40,300]: position 0.8*(5-1)=3.2,
 	// interpolating between index 3 (40) and index 4 (300): 40 + 0.2*(300-40) = 92.
+	// All counted jobs carry an assigned_flavor: the report counts only jobs we
+	// own, i.e. those whose labels matched one of our flavors.
 	day := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	waits := []int{10, 20, 30, 40, 300}
 	for i, w := range waits {
 		created := day.Add(-time.Duration(w) * time.Second)
 		_, err = pool.Exec(ctx, `
-			INSERT INTO job (platform, id, created_at, started_at, raw)
-			VALUES ($1, $2, $3, $4, '{}')`,
+			INSERT INTO job (platform, id, created_at, started_at, raw, assigned_flavor)
+			VALUES ($1, $2, $3, $4, '{}', 'small')`,
 			"github", fmt.Sprintf("job-%d", i), created, day)
 		require.NoError(t, err)
 	}
@@ -97,24 +99,34 @@ func TestReport_EndToEnd(t *testing.T) {
 	// Seed one job on a different day to confirm grouping.
 	otherDay := time.Date(2026, 5, 2, 1, 0, 0, 0, time.UTC)
 	_, err = pool.Exec(ctx, `
-		INSERT INTO job (platform, id, created_at, started_at, raw)
-		VALUES ($1, $2, $3, $4, '{}')`,
+		INSERT INTO job (platform, id, created_at, started_at, raw, assigned_flavor)
+		VALUES ($1, $2, $3, $4, '{}', 'small')`,
 		"github", "other-day", otherDay.Add(-60*time.Second), otherDay)
 	require.NoError(t, err)
 
 	// Seed one job with NULL started_at to confirm it is excluded.
 	_, err = pool.Exec(ctx, `
-		INSERT INTO job (platform, id, created_at, started_at, raw)
-		VALUES ($1, $2, $3, NULL, '{}')`,
+		INSERT INTO job (platform, id, created_at, started_at, raw, assigned_flavor)
+		VALUES ($1, $2, $3, NULL, '{}', 'small')`,
 		"github", "null-started", day.Add(-999*time.Second))
 	require.NoError(t, err)
 
 	// Seed one job where started_at < created_at (negative wait, -10s) to
 	// confirm it is clamped to 0 and kept in the population, not excluded.
 	_, err = pool.Exec(ctx, `
+		INSERT INTO job (platform, id, created_at, started_at, raw, assigned_flavor)
+		VALUES ($1, $2, $3, $4, '{}', 'small')`,
+		"github", "negative-wait", day.Add(10*time.Second), day)
+	require.NoError(t, err)
+
+	// Seed one job we don't own (NULL assigned_flavor) on day 1 with an
+	// otherwise-valid 50s wait, to confirm it is excluded from the P80 and the
+	// sample count. Without the assigned_flavor filter this would push day-1 to
+	// 7 samples and skew the percentile.
+	_, err = pool.Exec(ctx, `
 		INSERT INTO job (platform, id, created_at, started_at, raw)
 		VALUES ($1, $2, $3, $4, '{}')`,
-		"github", "negative-wait", day.Add(10*time.Second), day)
+		"github", "unowned", day.Add(-50*time.Second), day)
 	require.NoError(t, err)
 
 	cfg := config{
@@ -128,7 +140,7 @@ func TestReport_EndToEnd(t *testing.T) {
 	require.Len(t, rows, 2, "expected one row per day with started jobs")
 	assert.Equal(t, "2026-05-01", rows[0].Day.UTC().Format("2006-01-02"))
 	assert.Equal(t, "github", rows[0].Platform)
-	assert.Equal(t, int64(6), rows[0].SampleCount, "NULL-started excluded; negative-wait clamped to 0 and kept")
+	assert.Equal(t, int64(6), rows[0].SampleCount, "NULL-started and unowned (NULL flavor) excluded; negative-wait clamped to 0 and kept")
 	// The negative-wait job is clamped to 0, so the day-1 population is sorted
 	// [0,10,20,30,40,300] (n=6). percentile_cont(0.8) position 0.8*(6-1)=4.0
 	// lands exactly on index 4 -> 40.

--- a/cmd/waiting-p80-report/main.go
+++ b/cmd/waiting-p80-report/main.go
@@ -126,11 +126,11 @@ func buildQuery() string {
 		FROM job
 		WHERE started_at IS NOT NULL
 		  AND created_at IS NOT NULL
-		  -- Count only jobs we own: assigned_flavor is non-NULL exactly when a
-		  -- job's labels matched one of our configured flavors. Jobs served by
-		  -- runners we don't manage (e.g. third-party self-hosted runners on
-		  -- repos we ingest webhooks from) never match a flavor, so excluding
-		  -- NULL keeps their waiting times out of our P80.
+		  -- Count only jobs we own: assigned_flavor is non-NULL when a job's
+		  -- labels matched one of our configured flavors. Jobs served by
+		  -- runners we don't manage (for example, third-party self-hosted
+		  -- runners on repos we ingest webhooks from) never match a flavor, so
+		  -- excluding NULL keeps their waiting times out of our P80.
 		  AND assigned_flavor IS NOT NULL
 		  AND started_at >= @from
 		  AND started_at < @to

--- a/cmd/waiting-p80-report/main.go
+++ b/cmd/waiting-p80-report/main.go
@@ -2,7 +2,8 @@
 // job waiting time from the planner's PostgreSQL database into a CSV.
 //
 // It is not part of the planner charm. Run it ad hoc, from cron, or in CI. It
-// reads the planner's `job` table read-only.
+// reads the planner's `job` table read-only, and counts only jobs we own
+// (those assigned a flavor) so runners we don't manage don't skew the P80.
 //
 // Usage:
 //
@@ -125,6 +126,12 @@ func buildQuery() string {
 		FROM job
 		WHERE started_at IS NOT NULL
 		  AND created_at IS NOT NULL
+		  -- Count only jobs we own: assigned_flavor is non-NULL exactly when a
+		  -- job's labels matched one of our configured flavors. Jobs served by
+		  -- runners we don't manage (e.g. third-party self-hosted runners on
+		  -- repos we ingest webhooks from) never match a flavor, so excluding
+		  -- NULL keeps their waiting times out of our P80.
+		  AND assigned_flavor IS NOT NULL
 		  AND started_at >= @from
 		  AND started_at < @to
 		GROUP BY day, platform

--- a/cmd/waiting-p80-report/main_test.go
+++ b/cmd/waiting-p80-report/main_test.go
@@ -16,6 +16,7 @@ func TestBuildQuery(t *testing.T) {
 		{"percentile_cont(0.8)", "percentile_cont(0.8)"},
 		{"started_at guard", "started_at IS NOT NULL"},
 		{"created_at guard", "created_at IS NOT NULL"},
+		{"only jobs we own", "assigned_flavor IS NOT NULL"},
 		{"negative wait clamped to zero", "GREATEST(EXTRACT(EPOCH FROM (started_at - created_at)), 0)"},
 		{"day bucket", "date_trunc('day', started_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'"},
 		{"group by day", "GROUP BY day, platform"},

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-06-23
 
-- `waiting-p80-report`: count only jobs we own (those with a non-NULL `assigned_flavor`). Jobs served by runners we don't manage — for example, third-party self-hosted runners on repos we ingest webhooks from — never match a flavor and were skewing the reported P80. Caveat: for date ranges before the 2026-06-18 case-insensitive label-matching fix, some owned completed jobs were left with a NULL `assigned_flavor` and are likewise excluded, so `sample_count` may undercount for those older ranges.
+- `waiting-p80-report`: count only jobs we own (those with a non-NULL `assigned_flavor`). Jobs served by runners we don't manage — for example, third-party self-hosted runners on repositories we ingest webhooks from — never match a flavor and were skewing the reported P80. Caveat: for date ranges before the 2026-06-18 case-insensitive label-matching fix, some owned completed jobs were left with a NULL `assigned_flavor` and are likewise excluded, so `sample_count` may be lower than the true total for those older ranges.
 
 ## 2026-06-22
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-06-23
 
-- `waiting-p80-report`: count only jobs we own (those with a non-NULL `assigned_flavor`). Jobs served by runners we don't manage — for example, third-party self-hosted runners on repos we ingest webhooks from — never match a flavor and were skewing the reported P80.
+- `waiting-p80-report`: count only jobs we own (those with a non-NULL `assigned_flavor`). Jobs served by runners we don't manage — for example, third-party self-hosted runners on repos we ingest webhooks from — never match a flavor and were skewing the reported P80. Caveat: for date ranges before the 2026-06-18 case-insensitive label-matching fix, some owned completed jobs were left with a NULL `assigned_flavor` and are likewise excluded, so `sample_count` may undercount for those older ranges.
 
 ## 2026-06-22
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-23
+
+- `waiting-p80-report`: count only jobs we own (those with an `assigned_flavor`). Jobs served by runners we don't manage — e.g. third-party self-hosted runners on repos we ingest webhooks from — never match a flavor and were skewing the reported P80.
+
 ## 2026-06-22
 
 - `waiting-p80-report`: clamp negative waiting times (clock skew, `started_at < created_at`) to 0 instead of excluding those jobs. Previously dropping them removed the fastest jobs from the population and biased the reported P80 upward.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-06-23
 
-- `waiting-p80-report`: count only jobs we own (those with an `assigned_flavor`). Jobs served by runners we don't manage — e.g. third-party self-hosted runners on repos we ingest webhooks from — never match a flavor and were skewing the reported P80.
+- `waiting-p80-report`: count only jobs we own (those with a non-NULL `assigned_flavor`). Jobs served by runners we don't manage — for example, third-party self-hosted runners on repos we ingest webhooks from — never match a flavor and were skewing the reported P80.
 
 ## 2026-06-22
 


### PR DESCRIPTION
#### What this PR does

Restricts the `waiting-p80-report` CLI to jobs **we own** by adding `AND assigned_flavor IS NOT NULL` to its query. `assigned_flavor` is non-NULL exactly when a job's labels matched one of our configured flavors.

#### Why we need it

The planner ingests webhook events for jobs served by runners we don't manage (e.g. third-party self-hosted `spread-enabled` runners on repos we receive webhooks from). Those never match a flavor, so including them skewed the reported waiting-time P80.

#### Test plan

- Unit (`main_test.go`): asserts `buildQuery()` now emits the `assigned_flavor IS NOT NULL` predicate.
- E2E (`e2e_test.go`): seeds an unowned job (NULL flavor) with an otherwise-valid wait and confirms it is excluded from both the P80 and `sample_count`; existing seeded jobs now carry a flavor.

#### Review focus

The pre-2026-06-18 data caveat documented in `README.md`/`docs/changelog.md`: the case-insensitive label-matching fix (#243) only backfilled in-progress jobs, so completed jobs left at NULL flavor due to label casing remain excluded for older date ranges.

#### Breaking changes

None — read-only reporting tool, not part of any charm. `sample_count` will be lower (and the P80 more accurate) for ranges that previously included unowned jobs.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run)
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR involves Rockcraft:** I updated the version
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md`
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked whether the `AGENTS.md` "12-factor divergences" guidance still matches the upstream copilot-collections guidance

<sub>🤖 This PR description was prepared with AI assistance.</sub>

