### PR TITLE
feat(garm): register GitHub org/repo entities before scalesets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,11 @@ but some of its rules assume a hand-written `ops` charm and do **not** apply to 
 - **No separate reconcile logic** — `restart()` is the reconcile (see above). A thin `_reconcile` dispatcher that just calls `self.restart()` is fine; don't implement reconcile logic outside `restart()`.
 - **No hand-authored `workload.py` / Pebble layer** — the `go-framework` extension owns the
   workload; touch Pebble only inside a `restart()` override when strictly necessary.
-- **`state.py` Pydantic abstraction is optional** — only `garm-configurator` has a real
-  `CharmState`; don't force it onto paas charms.
+- **A `CharmState` abstraction is optional but encouraged where it cuts `charm.py` complexity**
+  (per [ISD014](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)).
+  `garm-configurator` uses a Pydantic `CharmState`; `garm` uses a `dataclasses`-based
+  `charm_state.py` (`CharmState.from_charm`) for relation-derived desired state. Don't force one
+  onto a trivial paas charm, and keep it dependency-free of `charm.py` (no import cycle).
 
 Still applicable: holistic state handling, idempotent `install`, explicit port handling, small
 `try/except` blocks scoped to custom exceptions, no Canonical-internal references in charm

--- a/charms/garm/AGENTS.md
+++ b/charms/garm/AGENTS.md
@@ -10,8 +10,10 @@ charm conventions; this file lists only what's specific to `garm`.
   - **DO** read them with plain `get_content()` (`_get_secrets`, `_get_admin_credentials`).
   - **DON'T** pass `refresh=True` — that's an observer concept (see root `AGENTS.md`).
 - **Domain logic is factored out of `charm.py`**: `src/garm_api.py` and `src/garm_client/`
-  (the GARM HTTP client). Extend these rather than growing the charm class. TOML rendering:
-  `render_garm_toml()` in `src/charm.py`.
+  (the GARM HTTP client), the per-resource reconcilers (`src/github_reconciler.py`,
+  `src/entity_reconciler.py`, `src/scaleset_reconciler.py`), and relation-derived desired state
+  (`src/charm_state.py` — `CharmState.from_charm`). Extend these rather than growing the charm
+  class. TOML rendering: `render_garm_toml()` in `src/charm.py`.
 - GARM serves its API and `/metrics` on one fixed port (`GARM_PORT`); the `app-port` /
   `metrics-port` / `metrics-path` config options have no effect (the charm logs a warning
   rather than blocking). The port is pinned in the `_workload_config` property.

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -899,6 +899,14 @@ class GarmCharm(paas_charm.go.Charm):
                     app_id = int(data.get("github_app_id", ""))
                     installation_id = int(data.get("github_installation_id", ""))
                 except ValueError:
+                    logger.warning(
+                        "Skipping entity %s from %s: non-numeric app/installation id "
+                        "(app_id=%r, installation_id=%r)",
+                        entity_name,
+                        unit.name,
+                        data.get("github_app_id", ""),
+                        data.get("github_installation_id", ""),
+                    )
                     continue
 
                 entities[entity_name] = EntitySpec(

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -20,6 +20,7 @@ import yaml
 from paas_charm.app import WorkloadConfig
 from paas_charm.charm_utils import block_if_invalid_data
 
+from entity_reconciler import EntityReconciler, EntitySpec
 from garm_api import GarmApiClient, GarmApiError, GarmAuthenticatedClient
 from github_reconciler import (
     DEFAULT_GITHUB_ENDPOINT,
@@ -322,6 +323,15 @@ def _parse_pre_install_scripts(raw: str) -> dict[str, str]:
     except ValueError:
         pass
     return {}
+
+
+def _credential_name(app_id: int, installation_id: int) -> str:
+    """Return the GARM credential name for a GitHub App installation.
+
+    The org/repo entity reconciler binds entities to credentials by this name, so both must
+    derive it identically.
+    """
+    return f"app-{app_id}-{installation_id}"
 
 
 class GarmCharm(paas_charm.go.Charm):
@@ -851,7 +861,7 @@ class GarmCharm(paas_charm.go.Charm):
                     continue
 
                 credentials[dedupe_key] = CredentialSpec(
-                    name=f"app-{app_id}-{installation_id}",
+                    name=_credential_name(app_id, installation_id),
                     endpoint=DEFAULT_GITHUB_ENDPOINT,
                     app_id=app_id,
                     installation_id=installation_id,
@@ -861,13 +871,51 @@ class GarmCharm(paas_charm.go.Charm):
 
         return list(credentials.values())
 
-    def _reconcile_runners(self) -> None:
-        """Sync GARM controller URLs, GitHub credentials, then scalesets from relation data.
+    def _build_desired_entities(self) -> list[EntitySpec]:
+        """Build desired GARM org/repo entities from configurator relation data.
 
-        The three steps are ordered, not independent: GARM rejects every operational call with
-        409 ``urls_required`` until the controller URLs are set, and scalesets reference the
-        GitHub credentials. So a single authenticated client configures the URLs and reconciles
-        credentials before scalesets are reconciled against the same client.
+        Each entity is bound to the GitHub App credential the github reconciler creates for the
+        same configurator unit (``app-<app_id>-<installation_id>``). A unit naming an org or repo
+        but lacking the App ids is skipped — its credential name cannot be derived. Entities are
+        deduped by name so several units sharing one org yield a single registration.
+
+        Returns:
+            The full desired set of entity specs.
+        """
+        entities: dict[str, EntitySpec] = {}
+        for relation in self.model.relations.get(GARM_CONFIGURATOR_RELATION_NAME, []):
+            for unit in relation.units:
+                data = relation.data[unit]
+                org = data.get("org", "")
+                repo = data.get("repo", "")
+                if org:
+                    entity_type, entity_name = "organization", org
+                elif repo:
+                    entity_type, entity_name = "repository", repo
+                else:
+                    continue
+
+                try:
+                    app_id = int(data.get("github_app_id", ""))
+                    installation_id = int(data.get("github_installation_id", ""))
+                except ValueError:
+                    continue
+
+                entities[entity_name] = EntitySpec(
+                    entity_type=entity_type,
+                    entity_name=entity_name,
+                    credentials_name=_credential_name(app_id, installation_id),
+                )
+        return list(entities.values())
+
+    def _reconcile_runners(self) -> None:
+        """Sync GARM controller URLs, GitHub credentials, entities, then scalesets.
+
+        The steps are ordered, not independent: GARM rejects every operational call with 409
+        ``urls_required`` until the controller URLs are set; org/repo entities reference a
+        credential by name; and scalesets are created under a registered entity. So a single
+        authenticated client configures the URLs and reconciles credentials, then entities, then
+        scalesets — each dependency before its dependants.
         """
         admin_creds = self._get_admin_credentials()
         if not admin_creds:
@@ -883,6 +931,7 @@ class GarmCharm(paas_charm.go.Charm):
             )
             self._ensure_controller_urls(auth_client)
             GithubReconciler(auth_client).reconcile(self._build_desired_credentials())
+            EntityReconciler(auth_client).reconcile(self._build_desired_entities())
             ScalesetReconciler(auth_client).reconcile(self._build_desired_scalesets())
             self.unit.status = ops.ActiveStatus()
         except GarmApiError as exc:

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -20,7 +20,8 @@ import yaml
 from paas_charm.app import WorkloadConfig
 from paas_charm.charm_utils import block_if_invalid_data
 
-from entity_reconciler import EntityReconciler, EntitySpec
+from charm_state import GARM_CONFIGURATOR_RELATION_NAME, CharmState, _credential_name
+from entity_reconciler import EntityReconciler
 from garm_api import GarmApiClient, GarmApiError, GarmAuthenticatedClient
 from github_reconciler import (
     DEFAULT_GITHUB_ENDPOINT,
@@ -36,7 +37,6 @@ GARM_CONFIG_PATH: typing.Final[str] = "/etc/garm/config.toml"
 GARM_PROVIDER_CONFIG_DIR: typing.Final[str] = "/etc/garm"
 GARM_SECRETS_LABEL: typing.Final[str] = "garm-secrets"
 GARM_ADMIN_CREDENTIALS_LABEL: typing.Final[str] = "garm-admin-credentials"
-GARM_CONFIGURATOR_RELATION_NAME: typing.Final[str] = "garm-configurator"
 CONTAINER_NAME: typing.Final[str] = "app"
 PEBBLE_SERVICE_NAME: typing.Final[str] = "app"
 GARM_BINARY: typing.Final[str] = "/usr/local/bin/garm"
@@ -323,15 +323,6 @@ def _parse_pre_install_scripts(raw: str) -> dict[str, str]:
     except ValueError:
         pass
     return {}
-
-
-def _credential_name(app_id: int, installation_id: int) -> str:
-    """Return the GARM credential name for a GitHub App installation.
-
-    The org/repo entity reconciler binds entities to credentials by this name, so both must
-    derive it identically.
-    """
-    return f"app-{app_id}-{installation_id}"
 
 
 class GarmCharm(paas_charm.go.Charm):
@@ -871,82 +862,8 @@ class GarmCharm(paas_charm.go.Charm):
 
         return list(credentials.values())
 
-    def _build_desired_entities(self) -> list[EntitySpec]:
-        """Build desired GARM org/repo entities from configurator relation data.
-
-        Each entity is bound to the GitHub App credential the github reconciler creates for the
-        same configurator unit (``app-<app_id>-<installation_id>``). A unit naming an org or repo
-        but lacking the App ids is skipped — its credential name cannot be derived. Entities are
-        deduped by (type, name) so several units sharing one org yield a single registration.
-
-        Returns:
-            The full desired set of entity specs.
-        """
-        entities: dict[tuple[str, str], EntitySpec] = {}
-        for relation in self.model.relations.get(GARM_CONFIGURATOR_RELATION_NAME, []):
-            for unit in relation.units:
-                data = relation.data[unit]
-                org = data.get("org", "")
-                repo = data.get("repo", "")
-                if org:
-                    entity_type, entity_name = "organization", org
-                elif repo:
-                    entity_type, entity_name = "repository", repo
-                else:
-                    continue
-
-                app_id_raw = data.get("github_app_id", "")
-                installation_id_raw = data.get("github_installation_id", "")
-                # Skip quietly while the App ids are merely absent (the configurator publishes the
-                # entity name before them during bring-up); warn only on malformed values.
-                if not (app_id_raw and installation_id_raw):
-                    continue
-                try:
-                    app_id = int(app_id_raw)
-                    installation_id = int(installation_id_raw)
-                except ValueError:
-                    logger.warning(
-                        "Skipping entity %s from %s: non-numeric app/installation id "
-                        "(app_id=%r, installation_id=%r)",
-                        entity_name,
-                        unit.name,
-                        app_id_raw,
-                        installation_id_raw,
-                    )
-                    continue
-
-                # Dedupe by (type, name) so an org and a repo sharing a raw name don't collide.
-                # Keep the first spec seen and warn if a later one derives a different credential,
-                # since multiple configurator relations make iteration order non-deterministic.
-                key = (entity_type, entity_name)
-                credentials_name = _credential_name(app_id, installation_id)
-                existing = entities.get(key)
-                if existing is not None:
-                    if existing.credentials_name != credentials_name:
-                        logger.warning(
-                            "Conflicting credential for %s '%s' (%s vs %s); keeping the first",
-                            entity_type,
-                            entity_name,
-                            existing.credentials_name,
-                            credentials_name,
-                        )
-                    continue
-                entities[key] = EntitySpec(
-                    entity_type=entity_type,
-                    entity_name=entity_name,
-                    credentials_name=credentials_name,
-                )
-        return list(entities.values())
-
     def _reconcile_runners(self) -> None:
-        """Sync GARM controller URLs, GitHub credentials, entities, then scalesets.
-
-        The steps are ordered, not independent: GARM rejects every operational call with 409
-        ``urls_required`` until the controller URLs are set; org/repo entities reference a
-        credential by name; and scalesets are created under a registered entity. So a single
-        authenticated client configures the URLs and reconciles credentials, then entities, then
-        scalesets — each dependency before its dependants.
-        """
+        """Reconcile GARM controller URLs, GitHub credentials, entities, and scalesets."""
         admin_creds = self._get_admin_credentials()
         if not admin_creds:
             logger.warning("Admin credentials not yet available; deferring reconcile")
@@ -959,9 +876,14 @@ class GarmCharm(paas_charm.go.Charm):
             auth_client = GarmAuthenticatedClient.from_login(
                 base_url, admin_creds["username"], admin_creds["password"]
             )
+            # The steps are ordered, not independent: GARM rejects every operational call with 409
+            # ``urls_required`` until the controller URLs are set; org/repo entities reference a
+            # credential by name; and scalesets are created under a registered entity. So a single
+            # authenticated client configures the URLs and reconciles credentials, then entities,
+            # then scalesets — each dependency before its dependants.
             self._ensure_controller_urls(auth_client)
             GithubReconciler(auth_client).reconcile(self._build_desired_credentials())
-            EntityReconciler(auth_client).reconcile(self._build_desired_entities())
+            EntityReconciler(auth_client).reconcile(CharmState.from_charm(self).desired_entities)
             ScalesetReconciler(auth_client).reconcile(self._build_desired_scalesets())
             self.unit.status = ops.ActiveStatus()
         except GarmApiError as exc:

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -895,17 +895,23 @@ class GarmCharm(paas_charm.go.Charm):
                 else:
                     continue
 
+                app_id_raw = data.get("github_app_id", "")
+                installation_id_raw = data.get("github_installation_id", "")
+                # Skip quietly while the App ids are merely absent (the configurator publishes the
+                # entity name before them during bring-up); warn only on malformed values.
+                if not (app_id_raw and installation_id_raw):
+                    continue
                 try:
-                    app_id = int(data.get("github_app_id", ""))
-                    installation_id = int(data.get("github_installation_id", ""))
+                    app_id = int(app_id_raw)
+                    installation_id = int(installation_id_raw)
                 except ValueError:
                     logger.warning(
                         "Skipping entity %s from %s: non-numeric app/installation id "
                         "(app_id=%r, installation_id=%r)",
                         entity_name,
                         unit.name,
-                        data.get("github_app_id", ""),
-                        data.get("github_installation_id", ""),
+                        app_id_raw,
+                        installation_id_raw,
                     )
                     continue
 

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -20,7 +20,7 @@ import yaml
 from paas_charm.app import WorkloadConfig
 from paas_charm.charm_utils import block_if_invalid_data
 
-from charm_state import GARM_CONFIGURATOR_RELATION_NAME, CharmState, _credential_name
+from charm_state import GARM_CONFIGURATOR_RELATION_NAME, CharmState, credential_name
 from entity_reconciler import EntityReconciler
 from garm_api import GarmApiClient, GarmApiError, GarmAuthenticatedClient
 from github_reconciler import (
@@ -852,7 +852,7 @@ class GarmCharm(paas_charm.go.Charm):
                     continue
 
                 credentials[dedupe_key] = CredentialSpec(
-                    name=_credential_name(app_id, installation_id),
+                    name=credential_name(app_id, installation_id),
                     endpoint=DEFAULT_GITHUB_ENDPOINT,
                     app_id=app_id,
                     installation_id=installation_id,

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -877,12 +877,12 @@ class GarmCharm(paas_charm.go.Charm):
         Each entity is bound to the GitHub App credential the github reconciler creates for the
         same configurator unit (``app-<app_id>-<installation_id>``). A unit naming an org or repo
         but lacking the App ids is skipped — its credential name cannot be derived. Entities are
-        deduped by name so several units sharing one org yield a single registration.
+        deduped by (type, name) so several units sharing one org yield a single registration.
 
         Returns:
             The full desired set of entity specs.
         """
-        entities: dict[str, EntitySpec] = {}
+        entities: dict[tuple[str, str], EntitySpec] = {}
         for relation in self.model.relations.get(GARM_CONFIGURATOR_RELATION_NAME, []):
             for unit in relation.units:
                 data = relation.data[unit]
@@ -915,10 +915,26 @@ class GarmCharm(paas_charm.go.Charm):
                     )
                     continue
 
-                entities[entity_name] = EntitySpec(
+                # Dedupe by (type, name) so an org and a repo sharing a raw name don't collide.
+                # Keep the first spec seen and warn if a later one derives a different credential,
+                # since multiple configurator relations make iteration order non-deterministic.
+                key = (entity_type, entity_name)
+                credentials_name = _credential_name(app_id, installation_id)
+                existing = entities.get(key)
+                if existing is not None:
+                    if existing.credentials_name != credentials_name:
+                        logger.warning(
+                            "Conflicting credential for %s '%s' (%s vs %s); keeping the first",
+                            entity_type,
+                            entity_name,
+                            existing.credentials_name,
+                            credentials_name,
+                        )
+                    continue
+                entities[key] = EntitySpec(
                     entity_type=entity_type,
                     entity_name=entity_name,
-                    credentials_name=_credential_name(app_id, installation_id),
+                    credentials_name=credentials_name,
                 )
         return list(entities.values())
 

--- a/charms/garm/src/charm_state.py
+++ b/charms/garm/src/charm_state.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Charm state parsing for the GARM charm.
+
+Consolidates the desired GARM state derived from charm relations into a single ``CharmState``
+value (built via ``CharmState.from_charm``), keeping ``charm.py`` free of relation-parsing detail.
+"""
+
+import dataclasses
+import logging
+import typing
+
+import ops
+
+from entity_reconciler import EntitySpec
+
+logger = logging.getLogger(__name__)
+
+GARM_CONFIGURATOR_RELATION_NAME: typing.Final[str] = "garm-configurator"
+
+
+def _credential_name(app_id: int, installation_id: int) -> str:
+    """Return the GARM credential name for a GitHub App installation.
+
+    The org/repo entity reconciler binds entities to credentials by this name, so both the
+    credential and entity builders must derive it identically.
+    """
+    return f"app-{app_id}-{installation_id}"
+
+
+def _get_desired_entities(charm: ops.CharmBase) -> list[EntitySpec]:
+    """Build the desired GARM org/repo entities from configurator relation data.
+
+    Each entity is bound to the GitHub App credential the github reconciler creates for the same
+    configurator unit (``app-<app_id>-<installation_id>``). A unit naming an org or repo but
+    lacking the App ids is skipped — its credential name cannot be derived.
+
+    Args:
+        charm: The charm instance.
+
+    Returns:
+        The full desired set of entity specs.
+    """
+    entities: dict[tuple[str, str], EntitySpec] = {}
+    for relation in charm.model.relations.get(GARM_CONFIGURATOR_RELATION_NAME, []):
+        for unit in relation.units:
+            data = relation.data[unit]
+            org = data.get("org", "")
+            repo = data.get("repo", "")
+            if org:
+                entity_type, entity_name = "organization", org
+            elif repo:
+                entity_type, entity_name = "repository", repo
+            else:
+                continue
+
+            app_id_raw = data.get("github_app_id", "")
+            installation_id_raw = data.get("github_installation_id", "")
+            # Skip quietly while the App ids are merely absent (the configurator publishes the
+            # entity name before them during bring-up); warn only on malformed values.
+            if not (app_id_raw and installation_id_raw):
+                continue
+            try:
+                app_id = int(app_id_raw)
+                installation_id = int(installation_id_raw)
+            except ValueError:
+                logger.warning(
+                    "Skipping entity %s from %s: non-numeric app/installation id "
+                    "(app_id=%r, installation_id=%r)",
+                    entity_name,
+                    unit.name,
+                    app_id_raw,
+                    installation_id_raw,
+                )
+                continue
+
+            # Dedupe by (type, name) so an org and a repo sharing a raw name don't collide. Keep
+            # the first spec seen and warn if a later one derives a different credential, since
+            # multiple configurator relations make iteration order non-deterministic.
+            key = (entity_type, entity_name)
+            credentials_name = _credential_name(app_id, installation_id)
+            existing = entities.get(key)
+            if existing is not None:
+                if existing.credentials_name != credentials_name:
+                    logger.warning(
+                        "Conflicting credential for %s '%s' (%s vs %s); keeping the first",
+                        entity_type,
+                        entity_name,
+                        existing.credentials_name,
+                        credentials_name,
+                    )
+                continue
+            entities[key] = EntitySpec(
+                entity_type=entity_type,
+                entity_name=entity_name,
+                credentials_name=credentials_name,
+            )
+    return list(entities.values())
+
+
+@dataclasses.dataclass(frozen=True)
+class CharmState:
+    """Consolidated desired state for the GARM charm.
+
+    Attributes:
+        desired_entities: GARM org/repo entities derived from the garm-configurator relation.
+    """
+
+    desired_entities: list[EntitySpec]
+
+    @classmethod
+    def from_charm(cls, charm: ops.CharmBase) -> "CharmState":
+        """Build CharmState from the current charm instance.
+
+        Args:
+            charm: The charm instance.
+
+        Returns:
+            Current CharmState.
+        """
+        return cls(desired_entities=_get_desired_entities(charm))

--- a/charms/garm/src/charm_state.py
+++ b/charms/garm/src/charm_state.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 GARM_CONFIGURATOR_RELATION_NAME: typing.Final[str] = "garm-configurator"
 
 
-def _credential_name(app_id: int, installation_id: int) -> str:
+def credential_name(app_id: int, installation_id: int) -> str:
     """Return the GARM credential name for a GitHub App installation.
 
     The org/repo entity reconciler binds entities to credentials by this name, so both the
@@ -87,7 +87,7 @@ def _get_desired_entities(charm: ops.CharmBase) -> list[EntitySpec]:
             # the first spec seen (iteration is ordered above) and warn if a later one derives a
             # different credential.
             key = (entity_type, entity_name)
-            credentials_name = _credential_name(app_id, installation_id)
+            credentials_name = credential_name(app_id, installation_id)
             existing = entities.get(key)
             if existing is not None:
                 if existing.credentials_name != credentials_name:

--- a/charms/garm/src/charm_state.py
+++ b/charms/garm/src/charm_state.py
@@ -43,8 +43,14 @@ def _get_desired_entities(charm: ops.CharmBase) -> list[EntitySpec]:
         The full desired set of entity specs.
     """
     entities: dict[tuple[str, str], EntitySpec] = {}
-    for relation in charm.model.relations.get(GARM_CONFIGURATOR_RELATION_NAME, []):
-        for unit in relation.units:
+    # Iterate relations and units in a stable order so the "keep the first" tie-break below is
+    # deterministic: relation.units is an unordered set, so without sorting two units naming the
+    # same entity with different credentials would flip-flop across reconciles.
+    relations = sorted(
+        charm.model.relations.get(GARM_CONFIGURATOR_RELATION_NAME, []), key=lambda r: r.id
+    )
+    for relation in relations:
+        for unit in sorted(relation.units, key=lambda unit: unit.name):
             data = relation.data[unit]
             org = data.get("org", "")
             repo = data.get("repo", "")
@@ -76,8 +82,8 @@ def _get_desired_entities(charm: ops.CharmBase) -> list[EntitySpec]:
                 continue
 
             # Dedupe by (type, name) so an org and a repo sharing a raw name don't collide. Keep
-            # the first spec seen and warn if a later one derives a different credential, since
-            # multiple configurator relations make iteration order non-deterministic.
+            # the first spec seen (iteration is ordered above) and warn if a later one derives a
+            # different credential.
             key = (entity_type, entity_name)
             credentials_name = _credential_name(app_id, installation_id)
             existing = entities.get(key)

--- a/charms/garm/src/charm_state.py
+++ b/charms/garm/src/charm_state.py
@@ -3,8 +3,10 @@
 
 """Charm state parsing for the GARM charm.
 
-Consolidates the desired GARM state derived from charm relations into a single ``CharmState``
-value (built via ``CharmState.from_charm``), keeping ``charm.py`` free of relation-parsing detail.
+Builds the desired GARM org/repo entities from the garm-configurator relation into a
+``CharmState`` value (via ``CharmState.from_charm``), keeping that relation-parsing out of
+``charm.py``. Credential and scaleset specs are still built in ``charm.py`` today; they can move
+here under the same pattern as the state grows.
 """
 
 import dataclasses
@@ -107,7 +109,7 @@ def _get_desired_entities(charm: ops.CharmBase) -> list[EntitySpec]:
 
 @dataclasses.dataclass(frozen=True)
 class CharmState:
-    """Consolidated desired state for the GARM charm.
+    """Desired GARM state derived from charm relations.
 
     Attributes:
         desired_entities: GARM org/repo entities derived from the garm-configurator relation.

--- a/charms/garm/src/entity_reconciler.py
+++ b/charms/garm/src/entity_reconciler.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/charms/garm/src/entity_reconciler.py
+++ b/charms/garm/src/entity_reconciler.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Entity reconciler: registers GARM org/repo entities so scalesets can be created under them.
+
+GARM requires an organization/repository entity (linked to a GitHub credential) to exist before a
+scaleset can be created under it. This reconciler sits between the credential reconciler and the
+scaleset reconciler: credentials are created first, the entity references a credential by name, and
+the scaleset reconciler then resolves the entity id. An entity is owned by the charm when it is
+bound to a charm-managed credential; only owned entities are updated or deleted.
+"""
+
+import logging
+from dataclasses import dataclass
+
+from garm_api import GarmApiError, GarmAuthenticatedClient
+from garm_client.models.create_org_params import CreateOrgParams
+from garm_client.models.create_repo_params import CreateRepoParams
+from garm_client.models.update_entity_params import UpdateEntityParams
+from github_reconciler import MANAGED_CREDENTIAL_DESCRIPTION
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EntitySpec:
+    """Desired state for one GARM entity (organization or repository)."""
+
+    entity_type: str  # "organization" | "repository"
+    entity_name: str  # org name, or "owner/repo"
+    credentials_name: str  # "app-<app_id>-<installation_id>"
+
+
+class EntityReconciler:
+    """Reconciles GARM org/repo entities against a desired spec list."""
+
+    def __init__(self, client: GarmAuthenticatedClient) -> None:
+        """Initialise the reconciler.
+
+        Args:
+            client: Authenticated GarmAuthenticatedClient instance.
+        """
+        self._client = client
+
+    def reconcile(self, desired: list[EntitySpec]) -> None:
+        """Register, update, or delete GARM entities to match *desired*.
+
+        Credentials are resolved by id so charm ownership can be attributed (an entity bound to a
+        charm-managed credential is owned by the charm). Both registration and deletion are
+        best-effort and deferred on failure: GARM validates an entity against GitHub when
+        registering it, and rejects deleting one while scalesets still reference it, so each is
+        retried on the next reconcile rather than aborting the pass or blocking other entities.
+
+        Args:
+            desired: The full desired set of entities across all configurator relations.
+        """
+        creds_by_id = {c.id: c for c in self._client.list_credentials() if c.id is not None}
+
+        self._reconcile_orgs(
+            {s.entity_name: s for s in desired if s.entity_type == "organization"}, creds_by_id
+        )
+        self._reconcile_repos(
+            {s.entity_name: s for s in desired if s.entity_type == "repository"}, creds_by_id
+        )
+
+    def _reconcile_orgs(self, desired: dict[str, EntitySpec], creds_by_id: dict) -> None:
+        observed = {org.name: org for org in self._client.list_orgs() if org.name}
+
+        for name, spec in desired.items():
+            existing = observed.get(name)
+            try:
+                if existing is None:
+                    logger.info("Registering organization '%s' in GARM", name)
+                    self._client.create_org(
+                        CreateOrgParams(name=name, credentials_name=spec.credentials_name)
+                    )
+                elif (
+                    self._needs_credential_update(existing, spec, creds_by_id, name)
+                    and existing.id
+                ):
+                    logger.info(
+                        "Updating organization '%s' credential -> '%s'",
+                        name,
+                        spec.credentials_name,
+                    )
+                    self._client.update_org(
+                        existing.id, UpdateEntityParams(credentials_name=spec.credentials_name)
+                    )
+            except GarmApiError as exc:
+                self._log_deferred("organization", name, exc)
+
+        for name, org in observed.items():
+            if name not in desired and org.id and self._is_managed(org, creds_by_id):
+                self._safe_delete(self._client.delete_org, org.id, "organization", name)
+
+    def _reconcile_repos(self, desired: dict[str, EntitySpec], creds_by_id: dict) -> None:
+        observed = {
+            f"{repo.owner}/{repo.name}": repo
+            for repo in self._client.list_repos()
+            if repo.owner and repo.name
+        }
+
+        for full_name, spec in desired.items():
+            existing = observed.get(full_name)
+            try:
+                if existing is None:
+                    owner, _, name = full_name.partition("/")
+                    logger.info("Registering repository '%s' in GARM", full_name)
+                    self._client.create_repo(
+                        CreateRepoParams(
+                            owner=owner, name=name, credentials_name=spec.credentials_name
+                        )
+                    )
+                elif (
+                    self._needs_credential_update(existing, spec, creds_by_id, full_name)
+                    and existing.id
+                ):
+                    logger.info(
+                        "Updating repository '%s' credential -> '%s'",
+                        full_name,
+                        spec.credentials_name,
+                    )
+                    self._client.update_repo(
+                        existing.id, UpdateEntityParams(credentials_name=spec.credentials_name)
+                    )
+            except GarmApiError as exc:
+                self._log_deferred("repository", full_name, exc)
+
+        for full_name, repo in observed.items():
+            if full_name not in desired and repo.id and self._is_managed(repo, creds_by_id):
+                self._safe_delete(self._client.delete_repo, repo.id, "repository", full_name)
+
+    @staticmethod
+    def _needs_credential_update(observed, spec: EntitySpec, creds_by_id: dict, name: str) -> bool:
+        """Return True if *observed*'s credential differs from the spec and is safe to change.
+
+        An entity bound to an operator-owned (unmanaged) credential is never overwritten; one with
+        no resolvable credential is unclaimed and safe to adopt.
+        """
+        current = creds_by_id.get(observed.credentials_id)
+        if (current.name if current else None) == spec.credentials_name:
+            return False
+        if current is not None and current.description != MANAGED_CREDENTIAL_DESCRIPTION:
+            logger.warning(
+                "Skipping credential update for '%s': bound to unmanaged credential '%s'",
+                name,
+                current.name,
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _is_managed(entity, creds_by_id: dict) -> bool:
+        # An entity is charm-owned when it is bound to a charm-managed credential. This relies on
+        # GARM rejecting deletion of a credential still referenced by an entity, so the managed
+        # credential outlives the entity during teardown and ownership stays attributable.
+        current = creds_by_id.get(entity.credentials_id)
+        return current is not None and current.description == MANAGED_CREDENTIAL_DESCRIPTION
+
+    @staticmethod
+    def _log_deferred(kind: str, name: str, exc: GarmApiError) -> None:
+        # Registration goes through GitHub (GARM validates the entity against the forge), so a
+        # transient GitHub/credential issue must not abort the whole reconcile or block scalesets
+        # for other entities. Defer like the scaleset reconciler does and retry on the next pass.
+        logger.warning(
+            "Deferring registration of %s '%s' (GARM could not register it yet; will retry): %s",
+            kind,
+            name,
+            exc,
+        )
+
+    @staticmethod
+    def _safe_delete(delete_fn, entity_id, kind: str, name: str) -> None:
+        logger.info("Deleting orphaned %s '%s' (id=%s)", kind, name, entity_id)
+        try:
+            delete_fn(entity_id)
+        except GarmApiError as exc:
+            logger.warning(
+                "Could not delete %s '%s' (scalesets may still reference it; will retry): %s",
+                kind,
+                name,
+                exc,
+            )

--- a/charms/garm/src/entity_reconciler.py
+++ b/charms/garm/src/entity_reconciler.py
@@ -106,6 +106,11 @@ class EntityReconciler:
             try:
                 if existing is None:
                     owner, _, name = full_name.partition("/")
+                    if not (owner and name):
+                        logger.warning(
+                            "Skipping repository '%s': expected 'owner/repo' format", full_name
+                        )
+                        continue
                     logger.info("Registering repository '%s' in GARM", full_name)
                     self._client.create_repo(
                         CreateRepoParams(

--- a/charms/garm/src/garm_api.py
+++ b/charms/garm/src/garm_api.py
@@ -22,13 +22,18 @@ from garm_client.api_client import ApiClient
 from garm_client.configuration import Configuration
 from garm_client.exceptions import ApiException
 from garm_client.models.create_github_credentials_params import CreateGithubCredentialsParams
+from garm_client.models.create_org_params import CreateOrgParams
+from garm_client.models.create_repo_params import CreateRepoParams
 from garm_client.models.create_scale_set_params import CreateScaleSetParams
 from garm_client.models.forge_credentials import ForgeCredentials
 from garm_client.models.new_user_params import NewUserParams
+from garm_client.models.organization import Organization
 from garm_client.models.password_login_params import PasswordLoginParams
 from garm_client.models.provider import Provider
+from garm_client.models.repository import Repository
 from garm_client.models.scale_set import ScaleSet
 from garm_client.models.update_controller_params import UpdateControllerParams
+from garm_client.models.update_entity_params import UpdateEntityParams
 from garm_client.models.update_github_credentials_params import UpdateGithubCredentialsParams
 from garm_client.models.update_scale_set_params import UpdateScaleSetParams
 
@@ -476,6 +481,202 @@ class GarmAuthenticatedClient(GarmApiClient):
             if f"{repo.owner}/{repo.name}" == repo_name:
                 return repo.id
         return None
+
+    def list_orgs(self) -> list[Organization]:
+        """List all GARM organizations.
+
+        Returns:
+            List of Organization model objects.
+
+        Raises:
+            GarmApiError: On API error.
+        """
+        with self._api_client() as client:
+            try:
+                return (
+                    OrganizationsApi(api_client=client).list_orgs(
+                        _request_timeout=_REQUEST_TIMEOUT
+                    )
+                    or []
+                )
+            except ApiException as exc:
+                raise GarmApiError(
+                    f"Failed to list organizations ({exc.status}): {exc.body}"
+                ) from exc
+            except urllib3.exceptions.HTTPError as exc:
+                raise GarmConnectionError(f"GARM connection error: {exc}") from exc
+
+    def list_repos(self) -> list[Repository]:
+        """List all GARM repositories.
+
+        Returns:
+            List of Repository model objects.
+
+        Raises:
+            GarmApiError: On API error.
+        """
+        with self._api_client() as client:
+            try:
+                return (
+                    RepositoriesApi(api_client=client).list_repos(
+                        _request_timeout=_REQUEST_TIMEOUT
+                    )
+                    or []
+                )
+            except ApiException as exc:
+                raise GarmApiError(
+                    f"Failed to list repositories ({exc.status}): {exc.body}"
+                ) from exc
+            except urllib3.exceptions.HTTPError as exc:
+                raise GarmConnectionError(f"GARM connection error: {exc}") from exc
+
+    def create_org(self, params: CreateOrgParams) -> Organization:
+        """Register an organization in GARM.
+
+        Args:
+            params: CreateOrgParams instance (name + credentials_name).
+
+        Returns:
+            Created Organization model object.
+
+        Raises:
+            GarmApiError: On API error.
+        """
+        with self._api_client() as client:
+            try:
+                return OrganizationsApi(api_client=client).create_org(
+                    body=params,
+                    _request_timeout=_REQUEST_TIMEOUT,
+                )
+            except ApiException as exc:
+                raise GarmApiError(
+                    f"Failed to create organization ({exc.status}): {exc.body}"
+                ) from exc
+            except urllib3.exceptions.HTTPError as exc:
+                raise GarmConnectionError(f"GARM connection error: {exc}") from exc
+
+    def update_org(self, org_id: str, params: UpdateEntityParams) -> Organization:
+        """Update an existing GARM organization.
+
+        Args:
+            org_id: GARM organization UUID.
+            params: UpdateEntityParams instance.
+
+        Returns:
+            Updated Organization model object.
+
+        Raises:
+            GarmApiError: On API error.
+        """
+        with self._api_client() as client:
+            try:
+                return OrganizationsApi(api_client=client).update_org(
+                    org_id=org_id,
+                    body=params,
+                    _request_timeout=_REQUEST_TIMEOUT,
+                )
+            except ApiException as exc:
+                raise GarmApiError(
+                    f"Failed to update organization {org_id} ({exc.status}): {exc.body}"
+                ) from exc
+            except urllib3.exceptions.HTTPError as exc:
+                raise GarmConnectionError(f"GARM connection error: {exc}") from exc
+
+    def delete_org(self, org_id: str) -> None:
+        """Delete a GARM organization.
+
+        Args:
+            org_id: GARM organization UUID.
+
+        Raises:
+            GarmApiError: On API error.
+        """
+        with self._api_client() as client:
+            try:
+                OrganizationsApi(api_client=client).delete_org(
+                    org_id=org_id,
+                    _request_timeout=_REQUEST_TIMEOUT,
+                )
+            except ApiException as exc:
+                raise GarmApiError(
+                    f"Failed to delete organization {org_id} ({exc.status}): {exc.body}"
+                ) from exc
+            except urllib3.exceptions.HTTPError as exc:
+                raise GarmConnectionError(f"GARM connection error: {exc}") from exc
+
+    def create_repo(self, params: CreateRepoParams) -> Repository:
+        """Register a repository in GARM.
+
+        Args:
+            params: CreateRepoParams instance (owner + name + credentials_name).
+
+        Returns:
+            Created Repository model object.
+
+        Raises:
+            GarmApiError: On API error.
+        """
+        with self._api_client() as client:
+            try:
+                return RepositoriesApi(api_client=client).create_repo(
+                    body=params,
+                    _request_timeout=_REQUEST_TIMEOUT,
+                )
+            except ApiException as exc:
+                raise GarmApiError(
+                    f"Failed to create repository ({exc.status}): {exc.body}"
+                ) from exc
+            except urllib3.exceptions.HTTPError as exc:
+                raise GarmConnectionError(f"GARM connection error: {exc}") from exc
+
+    def update_repo(self, repo_id: str, params: UpdateEntityParams) -> Repository:
+        """Update an existing GARM repository.
+
+        Args:
+            repo_id: GARM repository UUID.
+            params: UpdateEntityParams instance.
+
+        Returns:
+            Updated Repository model object.
+
+        Raises:
+            GarmApiError: On API error.
+        """
+        with self._api_client() as client:
+            try:
+                return RepositoriesApi(api_client=client).update_repo(
+                    repo_id=repo_id,
+                    body=params,
+                    _request_timeout=_REQUEST_TIMEOUT,
+                )
+            except ApiException as exc:
+                raise GarmApiError(
+                    f"Failed to update repository {repo_id} ({exc.status}): {exc.body}"
+                ) from exc
+            except urllib3.exceptions.HTTPError as exc:
+                raise GarmConnectionError(f"GARM connection error: {exc}") from exc
+
+    def delete_repo(self, repo_id: str) -> None:
+        """Delete a GARM repository.
+
+        Args:
+            repo_id: GARM repository UUID.
+
+        Raises:
+            GarmApiError: On API error.
+        """
+        with self._api_client() as client:
+            try:
+                RepositoriesApi(api_client=client).delete_repo(
+                    repo_id=repo_id,
+                    _request_timeout=_REQUEST_TIMEOUT,
+                )
+            except ApiException as exc:
+                raise GarmApiError(
+                    f"Failed to delete repository {repo_id} ({exc.status}): {exc.body}"
+                ) from exc
+            except urllib3.exceptions.HTTPError as exc:
+                raise GarmConnectionError(f"GARM connection error: {exc}") from exc
 
     def create_org_scaleset(self, org_id: str, params: CreateScaleSetParams) -> ScaleSet:
         """Create a scaleset under a GARM organization.

--- a/charms/garm/src/github_reconciler.py
+++ b/charms/garm/src/github_reconciler.py
@@ -7,7 +7,7 @@
 import logging
 from dataclasses import dataclass, field
 
-from garm_api import GarmAuthenticatedClient
+from garm_api import GarmApiError, GarmAuthenticatedClient
 from garm_client.models.create_github_credentials_params import CreateGithubCredentialsParams
 from garm_client.models.github_app import GithubApp
 from garm_client.models.update_github_credentials_params import UpdateGithubCredentialsParams
@@ -80,7 +80,18 @@ class GithubReconciler:
                 and cred.description == MANAGED_CREDENTIAL_DESCRIPTION
             ):
                 logger.info("Deleting orphaned GitHub credential '%s' (id=%s)", name, cred.id)
-                self._client.delete_credentials(cred.id)
+                try:
+                    self._client.delete_credentials(cred.id)
+                except GarmApiError as exc:
+                    # GARM rejects deleting a credential still referenced by an org/repo entity.
+                    # The entity reconciler removes the orphaned entity in this same pass, so the
+                    # credential becomes deletable on the next reconcile — don't abort this one.
+                    logger.warning(
+                        "Could not delete GitHub credential '%s' (still referenced; will retry):"
+                        " %s",
+                        name,
+                        exc,
+                    )
 
     def _create_credential(self, spec: CredentialSpec) -> None:
         params = CreateGithubCredentialsParams(

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -872,6 +872,10 @@ def test_reconcile_runners_reconciles_credentials_entities_then_scalesets():
     auth_client = mock_auth_cls.from_login.return_value
     # Controller URLs must be configured before any operational call, or GARM returns 409.
     charm._ensure_controller_urls.assert_called_once_with(auth_client)
+    # Each reconciler must be built against the same authenticated client.
+    mock_github_cls.assert_called_once_with(auth_client)
+    mock_entity_cls.assert_called_once_with(auth_client)
+    mock_scaleset_cls.assert_called_once_with(auth_client)
     mock_github_cls.return_value.reconcile.assert_called_once_with(credentials)
     mock_entity_cls.return_value.reconcile.assert_called_once_with(entities)
     mock_scaleset_cls.return_value.reconcile.assert_called_once_with(scalesets)

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -848,7 +848,6 @@ def test_reconcile_runners_reconciles_credentials_entities_then_scalesets():
     entities = [object()]
     scalesets = [object()]
     charm._build_desired_credentials = MagicMock(return_value=credentials)
-    charm._build_desired_entities = MagicMock(return_value=entities)
     charm._build_desired_scalesets = MagicMock(return_value=scalesets)
     charm._ensure_controller_urls = MagicMock()
     charm.restart = MagicMock()
@@ -858,8 +857,10 @@ def test_reconcile_runners_reconciles_credentials_entities_then_scalesets():
         patch("charm.GithubReconciler") as mock_github_cls,
         patch("charm.EntityReconciler") as mock_entity_cls,
         patch("charm.ScalesetReconciler") as mock_scaleset_cls,
+        patch("charm.CharmState") as mock_charm_state_cls,
         patch.object(GarmCharm, "unit", new_callable=PropertyMock) as mock_unit,
     ):
+        mock_charm_state_cls.from_charm.return_value.desired_entities = entities
         mock_unit.return_value = MagicMock()
         order = MagicMock()
         order.attach_mock(mock_github_cls.return_value.reconcile, "github")
@@ -1035,100 +1036,6 @@ def test_build_desired_credentials_skips_non_numeric_ids():
     credentials = GarmCharm._build_desired_credentials(charm)
 
     assert credentials == []
-
-
-@pytest.mark.parametrize(
-    "unit_data, expected_type, expected_name",
-    [
-        (
-            {"org": "canonical", "github_app_id": "12345", "github_installation_id": "67890"},
-            "organization",
-            "canonical",
-        ),
-        (
-            {"repo": "canonical/runner", "github_app_id": "1", "github_installation_id": "2"},
-            "repository",
-            "canonical/runner",
-        ),
-    ],
-    ids=["org-entity", "repo-entity"],
-)
-def test_build_desired_entities_builds_entity_from_relation(
-    unit_data, expected_type, expected_name
-):
-    """
-    arrange: A charm whose configurator relation exposes a unit naming an org or repo plus the
-        GitHub App ids.
-    act: Call _build_desired_entities.
-    assert: One entity is built with the right type/name, bound to the app-<id>-<id> credential.
-    """
-    charm = _github_charm([unit_data])
-
-    entities = GarmCharm._build_desired_entities(charm)
-
-    assert len(entities) == 1
-    entity = entities[0]
-    assert entity.entity_type == expected_type
-    assert entity.entity_name == expected_name
-    assert entity.credentials_name == "app-{}-{}".format(
-        unit_data["github_app_id"], unit_data["github_installation_id"]
-    )
-
-
-def test_build_desired_entities_dedupes_by_name():
-    """
-    arrange: A charm whose configurator relation exposes two units naming the same org.
-    act: Call _build_desired_entities.
-    assert: The two units collapse to a single entity registration.
-    """
-    unit_data = {"org": "canonical", "github_app_id": "1", "github_installation_id": "2"}
-    charm = _github_charm([dict(unit_data), dict(unit_data)])
-
-    entities = GarmCharm._build_desired_entities(charm)
-
-    assert len(entities) == 1
-
-
-def test_build_desired_entities_distinguishes_org_and_repo_with_same_name():
-    """
-    arrange: A configurator relation exposing an org and a repo that share the same raw name.
-    act: Call _build_desired_entities.
-    assert: Two distinct entities are produced — dedup is by (type, name), not name alone, so the
-        org and repo do not collide.
-    """
-    charm = _github_charm(
-        [
-            {"org": "shared", "github_app_id": "1", "github_installation_id": "2"},
-            {"repo": "shared", "github_app_id": "1", "github_installation_id": "2"},
-        ]
-    )
-
-    entities = GarmCharm._build_desired_entities(charm)
-
-    assert {(e.entity_type, e.entity_name) for e in entities} == {
-        ("organization", "shared"),
-        ("repository", "shared"),
-    }
-
-
-@pytest.mark.parametrize(
-    "unit_data",
-    [
-        {"github_app_id": "1", "github_installation_id": "2"},
-        {"org": "canonical", "github_installation_id": "2"},
-        {"org": "canonical", "github_app_id": "x", "github_installation_id": "2"},
-    ],
-    ids=["no-org-or-repo", "missing-app-id", "non-numeric-id"],
-)
-def test_build_desired_entities_skips_incomplete_unit(unit_data):
-    """
-    arrange: A charm whose configurator unit lacks an entity name or valid GitHub App ids.
-    act: Call _build_desired_entities.
-    assert: No entity is built.
-    """
-    charm = _github_charm([unit_data])
-
-    assert GarmCharm._build_desired_entities(charm) == []
 
 
 def test_ensure_controller_urls_sets_urls_from_base_url():

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -831,20 +831,24 @@ def test_reconcile_runners_skips_when_no_admin_credentials():
     mock_auth_cls.from_login.assert_not_called()
 
 
-def test_reconcile_runners_reconciles_github_then_scalesets():
+def test_reconcile_runners_reconciles_credentials_entities_then_scalesets():
     """
-    arrange: Admin credentials are available and the desired credential/scaleset specs are stubbed.
+    arrange: Admin credentials are available and the desired credential/entity/scaleset specs are
+        stubbed.
     act: Call _reconcile_runners().
-    assert: On a single authenticated client it configures controller URLs, reconciles GitHub
-        credentials, then reconciles scalesets, reports ActiveStatus, and never restarts.
+    assert: On a single authenticated client it configures controller URLs, then reconciles
+        credentials, entities, and scalesets in that dependency order, reports ActiveStatus, and
+        never restarts.
     """
     charm = object.__new__(GarmCharm)
     charm._get_admin_credentials = MagicMock(
         return_value={"username": "admin", "password": "TestPass-123!"}
     )
     credentials = [object()]
+    entities = [object()]
     scalesets = [object()]
     charm._build_desired_credentials = MagicMock(return_value=credentials)
+    charm._build_desired_entities = MagicMock(return_value=entities)
     charm._build_desired_scalesets = MagicMock(return_value=scalesets)
     charm._ensure_controller_urls = MagicMock()
     charm.restart = MagicMock()
@@ -852,10 +856,15 @@ def test_reconcile_runners_reconciles_github_then_scalesets():
     with (
         patch("charm.GarmAuthenticatedClient") as mock_auth_cls,
         patch("charm.GithubReconciler") as mock_github_cls,
+        patch("charm.EntityReconciler") as mock_entity_cls,
         patch("charm.ScalesetReconciler") as mock_scaleset_cls,
         patch.object(GarmCharm, "unit", new_callable=PropertyMock) as mock_unit,
     ):
         mock_unit.return_value = MagicMock()
+        order = MagicMock()
+        order.attach_mock(mock_github_cls.return_value.reconcile, "github")
+        order.attach_mock(mock_entity_cls.return_value.reconcile, "entity")
+        order.attach_mock(mock_scaleset_cls.return_value.reconcile, "scaleset")
         charm._reconcile_runners()
 
     expected_url = f"http://127.0.0.1:{GARM_PORT}/api/v1"
@@ -863,10 +872,11 @@ def test_reconcile_runners_reconciles_github_then_scalesets():
     auth_client = mock_auth_cls.from_login.return_value
     # Controller URLs must be configured before any operational call, or GARM returns 409.
     charm._ensure_controller_urls.assert_called_once_with(auth_client)
-    mock_github_cls.assert_called_once_with(auth_client)
     mock_github_cls.return_value.reconcile.assert_called_once_with(credentials)
-    mock_scaleset_cls.assert_called_once_with(auth_client)
+    mock_entity_cls.return_value.reconcile.assert_called_once_with(entities)
     mock_scaleset_cls.return_value.reconcile.assert_called_once_with(scalesets)
+    # Entities depend on credentials and scalesets depend on entities, so order matters.
+    assert [name for name, _, _ in order.mock_calls] == ["github", "entity", "scaleset"]
     charm.restart.assert_not_called()
 
 
@@ -1021,6 +1031,78 @@ def test_build_desired_credentials_skips_non_numeric_ids():
     credentials = GarmCharm._build_desired_credentials(charm)
 
     assert credentials == []
+
+
+@pytest.mark.parametrize(
+    "unit_data, expected_type, expected_name",
+    [
+        (
+            {"org": "canonical", "github_app_id": "12345", "github_installation_id": "67890"},
+            "organization",
+            "canonical",
+        ),
+        (
+            {"repo": "canonical/runner", "github_app_id": "1", "github_installation_id": "2"},
+            "repository",
+            "canonical/runner",
+        ),
+    ],
+    ids=["org-entity", "repo-entity"],
+)
+def test_build_desired_entities_builds_entity_from_relation(
+    unit_data, expected_type, expected_name
+):
+    """
+    arrange: A charm whose configurator relation exposes a unit naming an org or repo plus the
+        GitHub App ids.
+    act: Call _build_desired_entities.
+    assert: One entity is built with the right type/name, bound to the app-<id>-<id> credential.
+    """
+    charm = _github_charm([unit_data])
+
+    entities = GarmCharm._build_desired_entities(charm)
+
+    assert len(entities) == 1
+    entity = entities[0]
+    assert entity.entity_type == expected_type
+    assert entity.entity_name == expected_name
+    assert entity.credentials_name == "app-{}-{}".format(
+        unit_data["github_app_id"], unit_data["github_installation_id"]
+    )
+
+
+def test_build_desired_entities_dedupes_by_name():
+    """
+    arrange: A charm whose configurator relation exposes two units naming the same org.
+    act: Call _build_desired_entities.
+    assert: The two units collapse to a single entity registration.
+    """
+    unit_data = {"org": "canonical", "github_app_id": "1", "github_installation_id": "2"}
+    charm = _github_charm([dict(unit_data), dict(unit_data)])
+
+    entities = GarmCharm._build_desired_entities(charm)
+
+    assert len(entities) == 1
+
+
+@pytest.mark.parametrize(
+    "unit_data",
+    [
+        {"github_app_id": "1", "github_installation_id": "2"},
+        {"org": "canonical", "github_installation_id": "2"},
+        {"org": "canonical", "github_app_id": "x", "github_installation_id": "2"},
+    ],
+    ids=["no-org-or-repo", "missing-app-id", "non-numeric-id"],
+)
+def test_build_desired_entities_skips_incomplete_unit(unit_data):
+    """
+    arrange: A charm whose configurator unit lacks an entity name or valid GitHub App ids.
+    act: Call _build_desired_entities.
+    assert: No entity is built.
+    """
+    charm = _github_charm([unit_data])
+
+    assert GarmCharm._build_desired_entities(charm) == []
 
 
 def test_ensure_controller_urls_sets_urls_from_base_url():

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -1089,6 +1089,28 @@ def test_build_desired_entities_dedupes_by_name():
     assert len(entities) == 1
 
 
+def test_build_desired_entities_distinguishes_org_and_repo_with_same_name():
+    """
+    arrange: A configurator relation exposing an org and a repo that share the same raw name.
+    act: Call _build_desired_entities.
+    assert: Two distinct entities are produced — dedup is by (type, name), not name alone, so the
+        org and repo do not collide.
+    """
+    charm = _github_charm(
+        [
+            {"org": "shared", "github_app_id": "1", "github_installation_id": "2"},
+            {"repo": "shared", "github_app_id": "1", "github_installation_id": "2"},
+        ]
+    )
+
+    entities = GarmCharm._build_desired_entities(charm)
+
+    assert {(e.entity_type, e.entity_name) for e in entities} == {
+        ("organization", "shared"),
+        ("repository", "shared"),
+    }
+
+
 @pytest.mark.parametrize(
     "unit_data",
     [

--- a/charms/garm/tests/unit/test_charm_state.py
+++ b/charms/garm/tests/unit/test_charm_state.py
@@ -11,12 +11,17 @@ from charm_state import CharmState
 
 
 def _charm(units_data):
-    """Build a mock charm whose configurator relation exposes the given unit databags."""
+    """Build a mock charm whose configurator relation exposes the given unit databags.
+
+    Units carry real, ordered names so the reconciler's stable-sort tie-break is exercised.
+    """
     charm = MagicMock()
     relation = MagicMock()
+    relation.id = 0
     data_map = {}
-    for unit_data in units_data:
+    for i, unit_data in enumerate(units_data):
         unit = MagicMock()
+        unit.name = f"garm-configurator/{i}"
         data_map[unit] = unit_data
     relation.units = list(data_map)
     relation.data = data_map

--- a/charms/garm/tests/unit/test_charm_state.py
+++ b/charms/garm/tests/unit/test_charm_state.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for charm_state.py."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from charm_state import CharmState
+
+
+def _charm(units_data):
+    """Build a mock charm whose configurator relation exposes the given unit databags."""
+    charm = MagicMock()
+    relation = MagicMock()
+    data_map = {}
+    for unit_data in units_data:
+        unit = MagicMock()
+        data_map[unit] = unit_data
+    relation.units = list(data_map)
+    relation.data = data_map
+    charm.model.relations.get.return_value = [relation]
+    return charm
+
+
+def _entities(units_data):
+    return CharmState.from_charm(_charm(units_data)).desired_entities
+
+
+@pytest.mark.parametrize(
+    "unit_data, expected_type, expected_name",
+    [
+        (
+            {"org": "canonical", "github_app_id": "12345", "github_installation_id": "67890"},
+            "organization",
+            "canonical",
+        ),
+        (
+            {"repo": "canonical/runner", "github_app_id": "1", "github_installation_id": "2"},
+            "repository",
+            "canonical/runner",
+        ),
+    ],
+    ids=["org-entity", "repo-entity"],
+)
+def test_desired_entities_built_from_relation(unit_data, expected_type, expected_name):
+    """
+    arrange: A configurator relation exposing a unit naming an org or repo plus the GitHub App ids.
+    act: Build CharmState.desired_entities.
+    assert: One entity is built with the right type/name, bound to the app-<id>-<id> credential.
+    """
+    entities = _entities([unit_data])
+
+    assert len(entities) == 1
+    entity = entities[0]
+    assert entity.entity_type == expected_type
+    assert entity.entity_name == expected_name
+    assert entity.credentials_name == "app-{}-{}".format(
+        unit_data["github_app_id"], unit_data["github_installation_id"]
+    )
+
+
+def test_desired_entities_dedupe_by_name():
+    """
+    arrange: A configurator relation exposing two units naming the same org.
+    act: Build CharmState.desired_entities.
+    assert: The two units collapse to a single entity registration.
+    """
+    unit_data = {"org": "canonical", "github_app_id": "1", "github_installation_id": "2"}
+
+    assert len(_entities([dict(unit_data), dict(unit_data)])) == 1
+
+
+def test_desired_entities_keep_first_on_conflicting_credential():
+    """
+    arrange: Two configurator units name the same org but derive different credentials.
+    act: Build CharmState.desired_entities.
+    assert: A single entity is kept, bound to the first unit's credential.
+    """
+    entities = _entities(
+        [
+            {"org": "canonical", "github_app_id": "1", "github_installation_id": "2"},
+            {"org": "canonical", "github_app_id": "9", "github_installation_id": "9"},
+        ]
+    )
+
+    assert len(entities) == 1
+    assert entities[0].credentials_name == "app-1-2"
+
+
+def test_desired_entities_distinguish_org_and_repo_with_same_name():
+    """
+    arrange: A configurator relation exposing an org and a repo that share the same raw name.
+    act: Build CharmState.desired_entities.
+    assert: Two distinct entities are produced — dedup is by (type, name), not name alone, so the
+        org and repo do not collide.
+    """
+    entities = _entities(
+        [
+            {"org": "shared", "github_app_id": "1", "github_installation_id": "2"},
+            {"repo": "shared", "github_app_id": "1", "github_installation_id": "2"},
+        ]
+    )
+
+    assert {(e.entity_type, e.entity_name) for e in entities} == {
+        ("organization", "shared"),
+        ("repository", "shared"),
+    }
+
+
+@pytest.mark.parametrize(
+    "unit_data",
+    [
+        {"github_app_id": "1", "github_installation_id": "2"},
+        {"org": "canonical", "github_installation_id": "2"},
+        {"org": "canonical", "github_app_id": "x", "github_installation_id": "2"},
+    ],
+    ids=["no-org-or-repo", "missing-app-id", "non-numeric-id"],
+)
+def test_desired_entities_skip_incomplete_unit(unit_data):
+    """
+    arrange: A configurator unit lacking an entity name or valid GitHub App ids.
+    act: Build CharmState.desired_entities.
+    assert: No entity is built.
+    """
+    assert _entities([unit_data]) == []

--- a/charms/garm/tests/unit/test_entity_reconciler.py
+++ b/charms/garm/tests/unit/test_entity_reconciler.py
@@ -165,6 +165,19 @@ def test_delete_orphan_repo_when_managed():
     client.delete_repo.assert_called_once_with("repo-uuid")
 
 
+def test_repo_without_owner_is_skipped_not_created():
+    """
+    arrange: A desired repository whose name has no 'owner/repo' slash.
+    act: Reconcile it.
+    assert: create_repo is not called — a malformed name is skipped rather than registered with
+        an empty name and deferred forever.
+    """
+    client = _client(repos=[])
+    _reconcile(client, [EntitySpec("repository", "no-slash", "app-1-2")])
+
+    client.create_repo.assert_not_called()
+
+
 def test_create_failure_is_deferred_not_fatal():
     """
     arrange: Two desired orgs where registering the first raises GarmApiError (GARM cannot reach

--- a/charms/garm/tests/unit/test_entity_reconciler.py
+++ b/charms/garm/tests/unit/test_entity_reconciler.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the entity reconciler."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from entity_reconciler import EntityReconciler, EntitySpec
+from garm_api import GarmApiError
+from github_reconciler import MANAGED_CREDENTIAL_DESCRIPTION
+
+MANAGED_CRED = {"id": 1, "name": "app-1-2", "description": MANAGED_CREDENTIAL_DESCRIPTION}
+UNMANAGED_CRED = {"id": 2, "name": "op-cred", "description": "operator owned"}
+
+
+def _attrs(**kwargs):
+    m = MagicMock()
+    for key, value in kwargs.items():
+        setattr(m, key, value)
+    return m
+
+
+def _client(credentials=None, orgs=None, repos=None):
+    """Build a mock GarmAuthenticatedClient with pre-configured list responses."""
+    client = MagicMock()
+    client.list_credentials.return_value = [_attrs(**c) for c in (credentials or [MANAGED_CRED])]
+    client.list_orgs.return_value = [_attrs(**o) for o in (orgs or [])]
+    client.list_repos.return_value = [_attrs(**r) for r in (repos or [])]
+    return client
+
+
+def _reconcile(client, desired):
+    EntityReconciler(client).reconcile(desired)
+
+
+def test_create_org_when_missing():
+    """
+    arrange: A client with the managed credential and no registered orgs.
+    act: Reconcile a desired organization entity.
+    assert: create_org is called once with the org name and managed credential; no update/delete.
+    """
+    client = _client(orgs=[])
+    _reconcile(client, [EntitySpec("organization", "canonical", "app-1-2")])
+
+    client.create_org.assert_called_once()
+    params = client.create_org.call_args[0][0]
+    assert params.name == "canonical"
+    assert params.credentials_name == "app-1-2"
+    client.update_org.assert_not_called()
+    client.delete_org.assert_not_called()
+
+
+def test_create_repo_splits_owner_and_name():
+    """
+    arrange: A client with the managed credential and no registered repos.
+    act: Reconcile a desired repository entity named "owner/repo".
+    assert: create_repo is called once with owner and name split apart.
+    """
+    client = _client(repos=[])
+    _reconcile(client, [EntitySpec("repository", "canonical/runner", "app-1-2")])
+
+    client.create_repo.assert_called_once()
+    params = client.create_repo.call_args[0][0]
+    assert params.owner == "canonical"
+    assert params.name == "runner"
+    assert params.credentials_name == "app-1-2"
+
+
+def test_no_op_when_org_present_and_credential_matches():
+    """
+    arrange: A client with an org already bound to the desired managed credential.
+    act: Reconcile the same desired organization.
+    assert: No create, update, or delete is issued.
+    """
+    org = {"name": "canonical", "id": "org-uuid", "credentials_id": 1}
+    client = _client(orgs=[org])
+    _reconcile(client, [EntitySpec("organization", "canonical", "app-1-2")])
+
+    client.create_org.assert_not_called()
+    client.update_org.assert_not_called()
+    client.delete_org.assert_not_called()
+
+
+def test_update_org_when_credential_drifts():
+    """
+    arrange: An org bound to a managed credential whose name differs from the desired one.
+    act: Reconcile the org with a different (desired) credential name.
+    assert: update_org is called once with the org id and the new credential name.
+    """
+    managed_other = {"id": 1, "name": "app-9-9", "description": MANAGED_CREDENTIAL_DESCRIPTION}
+    org = {"name": "canonical", "id": "org-uuid", "credentials_id": 1}
+    client = _client(credentials=[managed_other], orgs=[org])
+    _reconcile(client, [EntitySpec("organization", "canonical", "app-1-2")])
+
+    client.update_org.assert_called_once()
+    org_id, params = client.update_org.call_args[0]
+    assert org_id == "org-uuid"
+    assert params.credentials_name == "app-1-2"
+
+
+def test_update_repo_when_credential_drifts():
+    """
+    arrange: A repo bound to a managed credential whose name differs from the desired one.
+    act: Reconcile the repo with a different (desired) credential name.
+    assert: update_repo is called once with the repo id and the new credential name.
+    """
+    managed_other = {"id": 1, "name": "app-9-9", "description": MANAGED_CREDENTIAL_DESCRIPTION}
+    repo = {"owner": "canonical", "name": "runner", "id": "repo-uuid", "credentials_id": 1}
+    client = _client(credentials=[managed_other], repos=[repo])
+    _reconcile(client, [EntitySpec("repository", "canonical/runner", "app-1-2")])
+
+    client.update_repo.assert_called_once()
+    repo_id, params = client.update_repo.call_args[0]
+    assert repo_id == "repo-uuid"
+    assert params.credentials_name == "app-1-2"
+
+
+def test_update_skipped_for_unmanaged_credential():
+    """
+    arrange: An org bound to an operator-owned (unmanaged) credential.
+    act: Reconcile the org with a different desired credential.
+    assert: update_org is not called — operator-owned bindings are never overwritten.
+    """
+    org = {"name": "canonical", "id": "org-uuid", "credentials_id": 2}
+    client = _client(credentials=[UNMANAGED_CRED], orgs=[org])
+    _reconcile(client, [EntitySpec("organization", "canonical", "app-1-2")])
+
+    client.update_org.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "credentials, credentials_id, expect_deleted",
+    [
+        ([MANAGED_CRED], 1, True),
+        ([UNMANAGED_CRED], 2, False),
+        ([MANAGED_CRED], None, False),
+    ],
+    ids=["managed-deleted", "unmanaged-kept", "no-credential-kept"],
+)
+def test_orphan_org_deletion_respects_ownership(credentials, credentials_id, expect_deleted):
+    """
+    arrange: A client with an orphan org bound to a managed, unmanaged, or absent credential.
+    act: Reconcile with no desired entities.
+    assert: Only a charm-managed orphan is deleted; others are preserved.
+    """
+    org = {"name": "stale", "id": "org-uuid", "credentials_id": credentials_id}
+    client = _client(credentials=credentials, orgs=[org])
+    _reconcile(client, [])
+
+    assert client.delete_org.called is expect_deleted
+
+
+def test_delete_orphan_repo_when_managed():
+    """
+    arrange: A client with an orphan repo bound to the managed credential.
+    act: Reconcile with no desired entities.
+    assert: delete_repo is called once with the repo id.
+    """
+    repo = {"owner": "canonical", "name": "runner", "id": "repo-uuid", "credentials_id": 1}
+    client = _client(repos=[repo])
+    _reconcile(client, [])
+
+    client.delete_repo.assert_called_once_with("repo-uuid")
+
+
+def test_create_failure_is_deferred_not_fatal():
+    """
+    arrange: Two desired orgs where registering the first raises GarmApiError (GARM cannot reach
+        GitHub yet).
+    act: Reconcile both.
+    assert: reconcile swallows the error and still attempts the second org — one bad entity does
+        not abort the pass or block the others.
+    """
+    client = _client(orgs=[])
+    client.create_org.side_effect = [GarmApiError("500 server error"), None]
+
+    _reconcile(
+        client,
+        [
+            EntitySpec("organization", "canonical", "app-1-2"),
+            EntitySpec("organization", "other", "app-1-2"),
+        ],
+    )
+
+    assert client.create_org.call_count == 2
+
+
+def test_orphan_delete_is_non_fatal():
+    """
+    arrange: A managed orphan org whose deletion raises GarmApiError (scalesets still reference it).
+    act: Reconcile with no desired entities.
+    assert: reconcile swallows the error so the pass continues; delete_org was attempted once.
+    """
+    org = {"name": "stale", "id": "org-uuid", "credentials_id": 1}
+    client = _client(orgs=[org])
+    client.delete_org.side_effect = GarmApiError("entity still has scalesets")
+
+    _reconcile(client, [])  # must not raise
+
+    client.delete_org.assert_called_once_with("org-uuid")

--- a/charms/garm/tests/unit/test_garm_api.py
+++ b/charms/garm/tests/unit/test_garm_api.py
@@ -501,3 +501,111 @@ def test_update_controller_raises_on_api_error():
                     callback_url="http://garm/api/v1/callbacks",
                     webhook_url="http://garm/webhooks",
                 )
+
+
+@pytest.mark.parametrize(
+    "method, api_name, list_attr",
+    [
+        ("list_orgs", "OrganizationsApi", "list_orgs"),
+        ("list_repos", "RepositoriesApi", "list_repos"),
+    ],
+    ids=["list-orgs", "list-repos"],
+)
+def test_list_entities_returns_list_or_empty(method, api_name, list_attr):
+    """
+    arrange: GarmAuthenticatedClient with the entity API returning one item, then None.
+    act: Call the list wrapper.
+    assert: The item is returned; a None API response maps to an empty list.
+    """
+    client = GarmAuthenticatedClient(BASE_URL, "token")
+    item = MagicMock()
+    item.name = "canonical"
+    with _stub_api_client(client):
+        with patch(f"garm_api.{api_name}") as MockApi:
+            getattr(MockApi.return_value, list_attr).return_value = [item]
+            assert [e.name for e in getattr(client, method)()] == ["canonical"]
+            getattr(MockApi.return_value, list_attr).return_value = None
+            assert getattr(client, method)() == []
+
+
+@pytest.mark.parametrize(
+    "method, api_name, api_method, args",
+    [
+        ("create_org", "OrganizationsApi", "create_org", (MagicMock(),)),
+        ("update_org", "OrganizationsApi", "update_org", ("org-uuid", MagicMock())),
+        ("create_repo", "RepositoriesApi", "create_repo", (MagicMock(),)),
+        ("update_repo", "RepositoriesApi", "update_repo", ("repo-uuid", MagicMock())),
+    ],
+    ids=["create-org", "update-org", "create-repo", "update-repo"],
+)
+def test_entity_write_returns_model(method, api_name, api_method, args):
+    """
+    arrange: GarmAuthenticatedClient with the entity API returning a model with id=7.
+    act: Call the create/update wrapper.
+    assert: The returned model is propagated.
+    """
+    client = GarmAuthenticatedClient(BASE_URL, "token")
+    result_model = MagicMock()
+    result_model.id = 7
+    with _stub_api_client(client):
+        with patch(f"garm_api.{api_name}") as MockApi:
+            getattr(MockApi.return_value, api_method).return_value = result_model
+            assert getattr(client, method)(*args).id == 7
+
+
+@pytest.mark.parametrize(
+    "method, api_name, api_method, args",
+    [
+        ("list_orgs", "OrganizationsApi", "list_orgs", ()),
+        ("create_org", "OrganizationsApi", "create_org", (MagicMock(),)),
+        ("update_org", "OrganizationsApi", "update_org", ("org-uuid", MagicMock())),
+        ("delete_org", "OrganizationsApi", "delete_org", ("org-uuid",)),
+        ("list_repos", "RepositoriesApi", "list_repos", ()),
+        ("create_repo", "RepositoriesApi", "create_repo", (MagicMock(),)),
+        ("update_repo", "RepositoriesApi", "update_repo", ("repo-uuid", MagicMock())),
+        ("delete_repo", "RepositoriesApi", "delete_repo", ("repo-uuid",)),
+    ],
+    ids=[
+        "list-orgs",
+        "create-org",
+        "update-org",
+        "delete-org",
+        "list-repos",
+        "create-repo",
+        "update-repo",
+        "delete-repo",
+    ],
+)
+def test_entity_wrapper_raises_on_api_error(method, api_name, api_method, args):
+    """
+    arrange: GarmAuthenticatedClient with the entity API raising ApiException.
+    act: Call the wrapper.
+    assert: The ApiException is translated to GarmApiError.
+    """
+    client = GarmAuthenticatedClient(BASE_URL, "token")
+    with _stub_api_client(client):
+        with patch(f"garm_api.{api_name}") as MockApi:
+            getattr(MockApi.return_value, api_method).side_effect = ApiException(status=400)
+            with pytest.raises(GarmApiError):
+                getattr(client, method)(*args)
+
+
+@pytest.mark.parametrize(
+    "method, api_name, api_method, arg",
+    [
+        ("delete_org", "OrganizationsApi", "delete_org", "org-uuid"),
+        ("delete_repo", "RepositoriesApi", "delete_repo", "repo-uuid"),
+    ],
+    ids=["delete-org", "delete-repo"],
+)
+def test_entity_delete_calls_api(method, api_name, api_method, arg):
+    """
+    arrange: GarmAuthenticatedClient with the entity API stubbed.
+    act: Call the delete wrapper.
+    assert: The generated delete method is invoked once.
+    """
+    client = GarmAuthenticatedClient(BASE_URL, "token")
+    with _stub_api_client(client):
+        with patch(f"garm_api.{api_name}") as MockApi:
+            getattr(client, method)(arg)
+            getattr(MockApi.return_value, api_method).assert_called_once()

--- a/charms/garm/tests/unit/test_github_reconciler.py
+++ b/charms/garm/tests/unit/test_github_reconciler.py
@@ -5,11 +5,8 @@
 
 from unittest.mock import MagicMock
 
-from github_reconciler import (
-    MANAGED_CREDENTIAL_DESCRIPTION,
-    CredentialSpec,
-    GithubReconciler,
-)
+from garm_api import GarmApiError
+from github_reconciler import MANAGED_CREDENTIAL_DESCRIPTION, CredentialSpec, GithubReconciler
 
 
 def _mock_client(credentials=None):
@@ -158,6 +155,23 @@ def test_nameless_observed_credential_ignored():
     reconciler = GithubReconciler(client)
     reconciler.reconcile([])
     client.delete_credentials.assert_not_called()
+
+
+def test_orphan_credential_delete_is_non_fatal():
+    """
+    arrange: A managed orphan credential whose deletion raises GarmApiError (an entity still
+        references it).
+    act: Reconcile with no desired credentials.
+    assert: reconcile swallows the error so the pass continues; delete_credentials was attempted.
+    """
+    existing = {"name": "stale-cred", "id": 42, "description": MANAGED_CREDENTIAL_DESCRIPTION}
+    client = _mock_client(credentials=[existing])
+    client.delete_credentials.side_effect = GarmApiError("credential still in use")
+    reconciler = GithubReconciler(client)
+
+    reconciler.reconcile([])  # must not raise
+
+    client.delete_credentials.assert_called_once_with(42)
 
 
 def test_update_skipped_when_observed_credential_has_no_id():

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -83,4 +83,5 @@ Diátaxis
 hostmetrics
 configurator
 scaleset
+scalesets
 OAuth

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-30
+
+- Register GARM organization and repository entities from the garm-configurator relation over the GARM REST API, binding each to its managed GitHub App credential. Entities are now created before scalesets are reconciled, so scalesets no longer wait indefinitely for an org/repo that nothing registered. Registration is best-effort: if GARM cannot register an entity yet (for example GitHub is briefly unreachable), the charm defers and retries rather than failing the whole sync. Entities that fall out of the relation are deleted once their scalesets have drained.
+
 ## 2026-06-29
 
 - Implement the webhook redelivery service.


### PR DESCRIPTION
#### What this PR does

Registers GARM organization and repository **entities** from the garm-configurator
relation, closing the gap between credential sync (#241) and scaleset sync (#236).
GARM requires an org/repo entity (bound to a credential) to exist before a scaleset
can be created under it — but nothing registered it, so the scaleset reconciler
skipped specs forever (`organization '<org>' not registered in GARM yet`).

A new `EntityReconciler` runs between the credential and scaleset reconcilers:

- builds desired entities from the relation, bound to the managed `app-<app_id>-<installation_id>` credential;
- creates / updates-on-drift / deletes orphans, with full lifecycle for both orgs and repos;
- attributes ownership via the `Managed by garm` credential marker — operator-owned entities are never overwritten or deleted.

Registration and deletion are **best-effort and deferred per entity**: GARM validates
an entity against GitHub, so a transient failure logs and retries on the next reconcile
instead of aborting the whole sync or blocking other entities. Orphan credential deletion
is likewise made non-fatal so teardown unwinds bottom-up (scaleset → entity → credential).

#### Why we need it

Without entity registration the charm can sync credentials and define scalesets but the
scalesets never get created, so no runners are ever provisioned. This makes the
relation-driven flow actually reach a working scaleset.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process — N/A, no process changes
- [ ] Technical author assigned for documentation changes — N/A, only `docs/changelog.md` touched
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** workflow `modules` list correct — N/A, no new module (extended behaviour covered by existing `test_garm.py`)
- [ ] **If this PR involves a Grafana dashboard** — N/A
- [ ] **If this PR involves Terraform** — N/A
- [ ] **If this PR involves Rockcraft** — N/A, no rock change
- [ ] **If this PR adds/removes a charm or changes conventions/tooling/structure:** update `AGENTS.md` — N/A, new `src` module only, no convention change
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`** — N/A

#### Test plan

- **Unit:** `tox -c tox.toml` green — 149 tests; new `test_entity_reconciler.py`, plus additions to `test_garm_api.py`, `test_charm.py` (incl. reconcile-ordering), `test_github_reconciler.py`. Coverage: `entity_reconciler` 97%, `github_reconciler` 100%.
- **Integration:** `test_garm.py` — **12 passed** on a live microk8s/juju model with the packed charm. The first run caught a real bug (a 500 on org registration aborted the whole reconcile as `GARM sync failed`); fixing it to defer made `test_scaleset_created_and_updated_via_relation` and `test_garm_charm_reaches_active` pass.

#### Review focus

- **Deferral semantics** (`EntityReconciler._log_deferred`): registration failures are swallowed and retried, mirroring the scaleset reconciler's deferred-creation; the unit stays active rather than blocking on a GitHub hiccup.
- **Ownership / teardown ordering**: deletion only touches entities bound to a managed credential, and relies on GARM rejecting credential deletion while an entity references it — hence the non-fatal credential delete.

#### Potential breaking changes

None. Behaviour only adds entity registration; no config or relation schema changes.

#### New dependencies / APIs / modules

- New module `charms/garm/src/entity_reconciler.py`.
- New `garm_api` wrappers (`list/create/update/delete` for orgs and repos). No new third-party dependencies.
