### PR TITLE
fix(garm): add CA trust store to bare rock so GARM can verify TLS

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-02
+
+- Fix TLS verification in the GARM workload: the GARM rock is built on a bare base and previously shipped without a CA trust store, so GARM's statically-linked binary rejected every HTTPS certificate (including GitHub's) with `x509: certificate signed by unknown authority`. The rock now bundles the system CA certificates.
+
 ## 2026-06-30
 
 - Register GARM organization and repository entities from the garm-configurator relation over the GARM REST API, binding each to its managed GitHub App credential. Entities are now created before scalesets are reconciled, so scalesets no longer wait indefinitely for an org/repo that nothing registered. Registration is best-effort: if GARM cannot register an entity yet (for example GitHub is briefly unreachable), the charm defers and retries rather than failing the whole sync. Entities that fall out of the relation are deleted once their scalesets have drained.

--- a/garm-rockcraft.yaml
+++ b/garm-rockcraft.yaml
@@ -49,6 +49,15 @@ parts:
       mkdir -p "$CRAFT_PART_INSTALL/usr/local/bin"
       cp bin/garm-provider-openstack "$CRAFT_PART_INSTALL/usr/local/bin/"
 
+  # Bare rocks ship no CA trust store, so GARM's static Go binary trusts no
+  # root CAs. This chisel slice provides the pre-generated
+  # /etc/ssl/certs/ca-certificates.crt bundle so TLS verification works,
+  # mirroring the go-framework extension's runtime part.
+  runtime:
+    plugin: nil
+    stage-packages:
+      - ca-certificates_data
+
   pebble-layer:
     plugin: nil
     override-build: |


### PR DESCRIPTION
#### What this PR does

Adds a `runtime` part to the GARM rock that stages the `ca-certificates_data` chisel slice, giving the bare-base image a CA trust store (`/etc/ssl/certs/ca-certificates.crt`).

#### Why we need it

The GARM rock uses `base: bare` and shipped only the two static Go binaries — no CA bundle. GARM's statically-linked Go binary reads the system trust store from disk, so with no `ca-certificates.crt` it trusted no roots and rejected **every** HTTPS certificate, including GitHub's genuine one, with:

```
x509: certificate signed by unknown authority
```

This surfaced as repeated `failed to get rate limit` errors in the GARM workload. It is not a proxy-trust issue — the proxy delivers a publicly-trusted cert; the workload simply had nothing to verify it against. The `go-framework` rockcraft extension injects an equivalent runtime part for its own rocks, but the GARM rock is hand-written (GARM is upstream third-party code, so it can't use that extension), so it never got one.

The `ca-certificates_data` slice provides the *pre-generated* bundle, so it works on a bare base without needing the `update-ca-certificates` postinst to run.

#### Test plan

- Rebuilt the rock with `build-garm-rock.sh` (succeeds; `Priming runtime` step runs).
- Inspected the packed `garm_0.1_amd64.rock`: `/etc/ssl/certs/ca-certificates.crt` is now present (previously **absent** — confirmed 0 matches before the change, 1 after).
- No unit/integration tests apply — this is a rock build-definition change with no Python/Go surface.

#### Review focus

- The fix mirrors the `go-framework` extension's runtime part (`stage-packages: ["ca-certificates_data"]`); reviewers familiar with the extension will recognise it.
- No version bump: the rock `version` field is static (`0.1`, never bumped in history); this repo versions user-relevant changes via `docs/changelog.md`, which is updated here.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — n/a
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — n/a (only a changelog entry)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration) — n/a (rock build definition; no code surface to test)
- [ ] **If integration test modules are used:** I updated the workflow configuration — n/a
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard — n/a
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors — n/a
- [ ] **If this PR involves Rockcraft:** I updated the version — n/a (rock version is static `0.1`; changelog is the versioning mechanism)
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md` — n/a (no convention/structure change)
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked whether the `AGENTS.md` "12-factor divergences" guidance still matches — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
