### PR TITLE
Validate garm configurator max runner

### DIFF
--- a/charms/garm-configurator/charmcraft.yaml
+++ b/charms/garm-configurator/charmcraft.yaml
@@ -84,7 +84,7 @@ config:
         Minimum number of idle runners in the scaleset.
     max-runner:
       type: int
-      default: 0
+      default: 1
       description: |
         Maximum number of runners in the scaleset.
     labels:

--- a/charms/garm-configurator/charmcraft.yaml
+++ b/charms/garm-configurator/charmcraft.yaml
@@ -86,7 +86,7 @@ config:
       type: int
       default: 1
       description: |
-        Maximum number of runners in the scaleset.
+        Maximum number of runners in the scaleset. Must be greater than 0.
     labels:
       type: string
       description: |

--- a/charms/garm-configurator/src/charm_state.py
+++ b/charms/garm-configurator/src/charm_state.py
@@ -254,6 +254,10 @@ class ScalesetConfig(BaseModel):
             raise CharmConfigInvalidError(
                 f"{SCALESET_MAX_RUNNER_CONFIG_NAME} must be non-negative"
             )
+        if max_runner == 0:
+            raise CharmConfigInvalidError(
+                f"{SCALESET_MAX_RUNNER_CONFIG_NAME} must be greater than 0"
+            )
         if max_runner < min_idle_runner:
             raise CharmConfigInvalidError(
                 f"{SCALESET_MAX_RUNNER_CONFIG_NAME} must be greater than or equal to "

--- a/charms/garm-configurator/src/charm_state.py
+++ b/charms/garm-configurator/src/charm_state.py
@@ -250,11 +250,7 @@ class ScalesetConfig(BaseModel):
             )
 
         max_runner = int(charm.config.get(SCALESET_MAX_RUNNER_CONFIG_NAME, 0))
-        if max_runner < 0:
-            raise CharmConfigInvalidError(
-                f"{SCALESET_MAX_RUNNER_CONFIG_NAME} must be non-negative"
-            )
-        if max_runner == 0:
+        if max_runner <= 0:
             raise CharmConfigInvalidError(
                 f"{SCALESET_MAX_RUNNER_CONFIG_NAME} must be greater than 0"
             )

--- a/charms/garm-configurator/tests/unit/test_charm.py
+++ b/charms/garm-configurator/tests/unit/test_charm.py
@@ -133,6 +133,11 @@ _MISSING_CONFIG_SENTINEL = object()
             id="negative-max-runner",
         ),
         pytest.param(
+            {"max-runner": 0},
+            "max-runner must be greater than 0",
+            id="zero-max-runner",
+        ),
+        pytest.param(
             {"min-idle-runner": 5, "max-runner": 3},
             "max-runner must be greater than or equal to min-idle-runner",
             id="max-runner-less-than-min-idle-runner",

--- a/charms/garm-configurator/tests/unit/test_charm.py
+++ b/charms/garm-configurator/tests/unit/test_charm.py
@@ -129,7 +129,7 @@ _MISSING_CONFIG_SENTINEL = object()
         ),
         pytest.param(
             {"max-runner": -5},
-            "max-runner must be non-negative",
+            "max-runner must be greater than 0",
             id="negative-max-runner",
         ),
         pytest.param(

--- a/charms/garm-configurator/tox.toml
+++ b/charms/garm-configurator/tox.toml
@@ -37,7 +37,7 @@ commands = [
 
 [env.unit]
 description = "Run unit tests"
-deps = ["pytest", "coverage[toml]", "ops-scenario==8.7.1", "-r requirements.txt"]
+deps = ["pytest", "coverage[toml]", "ops-scenario==8.8.0", "-r requirements.txt"]
 commands = [
   [
     "coverage",

--- a/charms/tests/integration/test_garm_configurator.py
+++ b/charms/tests/integration/test_garm_configurator.py
@@ -53,6 +53,7 @@ def deploy_garm_configurator_app_fixture(
             "name": "test-scaleset",
             "flavor": "m1.large",
             "os-arch": "amd64",
+            "max-runner": "1",
             "repo": "myorg/myrepo",
         },
     )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-06
+
+- `garm-configurator`: reject `max-runner=0` during config validation. GARM rejects scale set creation with `max_runners cannot be 0`, so the charm now surfaces the invalid configuration before publishing unusable scale set data to GARM.
+
 ## 2026-07-02
 
 - Fix GARM organization and repository registration: the charm now sets a webhook secret when registering entities. GARM requires a non-empty webhook secret to register an org/repo, so registration previously failed with an opaque server error and scalesets were never created. The charm generates a throwaway secret automatically, so no operator configuration is required.


### PR DESCRIPTION
#### What this PR does

Ensure max-runner is set to non-zero value

#### Why we need it

GARM rejects scalesets with max-runners=0

```
  if s.MaxRunners == 0 {
      return fmt.Errorf("max_runners cannot be 0")
  }

  Path: parts/garm/src/params/requests.go
```

#### Checklist

- [ ] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run)
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR involves Rockcraft:** I updated the version
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md`
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked whether the `AGENTS.md` "12-factor divergences" guidance still matches the upstream copilot-collections guidance

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

