### PR TITLE
fix(garm-configurator): log full config validation error, shorten blocked status

### DIFF
--- a/charms/garm-configurator/src/charm.py
+++ b/charms/garm-configurator/src/charm.py
@@ -5,6 +5,7 @@
 """Charm entrypoint for the GARM configurator charm."""
 
 import json
+import logging
 import typing
 
 import ops
@@ -15,6 +16,8 @@ from charm_state import (
     CharmConfigInvalidError,
     CharmState,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class GarmConfiguratorCharm(ops.CharmBase):
@@ -52,7 +55,8 @@ class GarmConfiguratorCharm(ops.CharmBase):
         try:
             state = CharmState.from_charm(self)
         except CharmConfigInvalidError as e:
-            self.unit.status = ops.BlockedStatus(e.msg)
+            logger.warning("Invalid charm config:\n%s", e.msg)
+            self.unit.status = ops.BlockedStatus("Invalid charm config")
             return
 
         self._update_image_relation(state)

--- a/charms/garm-configurator/src/charm.py
+++ b/charms/garm-configurator/src/charm.py
@@ -55,8 +55,10 @@ class GarmConfiguratorCharm(ops.CharmBase):
         try:
             state = CharmState.from_charm(self)
         except CharmConfigInvalidError as e:
+            # Juju shows only the first line of a status message, so log the full
+            # detail (a pydantic error may span several lines) for debug-log.
             logger.warning("Invalid charm config:\n%s", e.msg)
-            self.unit.status = ops.BlockedStatus("Invalid charm config")
+            self.unit.status = ops.BlockedStatus(e.msg)
             return
 
         self._update_image_relation(state)

--- a/charms/garm-configurator/tests/unit/test_charm.py
+++ b/charms/garm-configurator/tests/unit/test_charm.py
@@ -154,14 +154,11 @@ _MISSING_CONFIG_SENTINEL = object()
         ),
     ],
 )
-def test_charm_blocked_invalid_config(
-    config_mutations: dict, expected_message: str, caplog: pytest.LogCaptureFixture
-):
+def test_charm_blocked_invalid_config(config_mutations: dict, expected_message: str):
     """
     arrange: Config is invalid (missing, empty, or has an invalid value).
     act: Run config-changed.
-    assert: Unit status is Blocked with a short, stable message, and the
-        specific validation detail is logged as a warning.
+    assert: Unit status is Blocked with the expected message.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -174,19 +171,35 @@ def test_charm_blocked_invalid_config(
             config[key] = value
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
+    assert out.unit_status == ops.BlockedStatus(expected_message)
+
+
+def test_charm_logs_invalid_config_detail(caplog: pytest.LogCaptureFixture):
+    """
+    arrange: A required config value is missing.
+    act: Run config-changed.
+    assert: The full validation detail is logged at WARNING level, so it is
+        discoverable in juju debug-log even when Juju truncates the status.
+    """
+    ctx = Context(GarmConfiguratorCharm)
+    secret = _make_secret()
+    pk_secret = _make_private_key_secret()
+    config = _valid_config(secret, pk_secret)
+    del config["openstack-auth-url"]
+    state = State(config=config, secrets=[secret, pk_secret])
+    ctx.run(ctx.on.config_changed(), state)
     assert any(
-        record.levelname == "WARNING" and expected_message in record.message
+        record.levelname == "WARNING"
+        and "Missing required configuration: openstack-auth-url" in record.message
         for record in caplog.records
     )
 
 
-def test_charm_blocked_password_secret_missing_value_key(caplog: pytest.LogCaptureFixture):
+def test_charm_blocked_password_secret_missing_value_key():
     """
     arrange: openstack-password secret exists but lacks 'value' key.
     act: Run config-changed.
-    assert: Unit status is Blocked with a short message, and the specific
-        detail is logged as a warning.
+    assert: Unit status is Blocked.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = Secret(tracked_content={"wrong-key": "data"})
@@ -194,20 +207,16 @@ def test_charm_blocked_password_secret_missing_value_key(caplog: pytest.LogCaptu
     config = _valid_config(secret, pk_secret)
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
-    assert any(
-        record.levelname == "WARNING"
-        and "openstack-password secret is invalid or missing 'value' key" in record.message
-        for record in caplog.records
+    assert out.unit_status == ops.BlockedStatus(
+        "openstack-password secret is invalid or missing 'value' key"
     )
 
 
-def test_charm_blocked_password_secret_not_found(caplog: pytest.LogCaptureFixture):
+def test_charm_blocked_password_secret_not_found():
     """
     arrange: openstack-password references a secret that doesn't exist in state.
     act: Run config-changed.
-    assert: Unit status is Blocked with a short message, and the specific
-        detail is logged as a warning.
+    assert: Unit status is Blocked.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -215,11 +224,8 @@ def test_charm_blocked_password_secret_not_found(caplog: pytest.LogCaptureFixtur
     config = _valid_config(secret, pk_secret)
     state = State(config=config, secrets=[pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
-    assert any(
-        record.levelname == "WARNING"
-        and "openstack-password secret is invalid or missing 'value' key" in record.message
-        for record in caplog.records
+    assert out.unit_status == ops.BlockedStatus(
+        "openstack-password secret is invalid or missing 'value' key"
     )
 
 
@@ -239,14 +245,11 @@ def test_charm_not_blocked_with_http_auth_url():
     assert not isinstance(out.unit_status, ops.BlockedStatus)
 
 
-def test_charm_blocked_github_app_private_key_secret_missing_value_key(
-    caplog: pytest.LogCaptureFixture,
-):
+def test_charm_blocked_github_app_private_key_secret_missing_value_key():
     """
     arrange: github-app-private-key secret exists but lacks 'value' key.
     act: Run config-changed.
-    assert: Unit status is Blocked with a short message, and the specific
-        detail is logged as a warning.
+    assert: Unit status is Blocked.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -254,20 +257,16 @@ def test_charm_blocked_github_app_private_key_secret_missing_value_key(
     config = _valid_config(secret, bad_pk_secret)
     state = State(config=config, secrets=[secret, bad_pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
-    assert any(
-        record.levelname == "WARNING"
-        and "github-app-private-key secret is invalid or missing 'value' key" in record.message
-        for record in caplog.records
+    assert out.unit_status == ops.BlockedStatus(
+        "github-app-private-key secret is invalid or missing 'value' key"
     )
 
 
-def test_charm_blocked_github_app_private_key_secret_not_found(caplog: pytest.LogCaptureFixture):
+def test_charm_blocked_github_app_private_key_secret_not_found():
     """
     arrange: github-app-private-key references a secret not in state.
     act: Run config-changed.
-    assert: Unit status is Blocked with a short message, and the specific
-        detail is logged as a warning.
+    assert: Unit status is Blocked.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -275,11 +274,8 @@ def test_charm_blocked_github_app_private_key_secret_not_found(caplog: pytest.Lo
     config = _valid_config(secret, pk_secret)
     state = State(config=config, secrets=[secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
-    assert any(
-        record.levelname == "WARNING"
-        and "github-app-private-key secret is invalid or missing 'value' key" in record.message
-        for record in caplog.records
+    assert out.unit_status == ops.BlockedStatus(
+        "github-app-private-key secret is invalid or missing 'value' key"
     )
 
 
@@ -662,7 +658,6 @@ def test_reconcile_writes_optional_scaleset_fields_to_garm_relation():
     )
     assert "repo" not in garm_out.local_unit_data
 
-
 @pytest.mark.parametrize(
     "config_key, bad_value, expected_fragment",
     [
@@ -729,15 +724,12 @@ def test_reconcile_writes_optional_scaleset_fields_to_garm_relation():
     ],
 )
 def test_charm_blocked_invalid_runner_config(
-    config_key: str, bad_value: str, expected_fragment: str, caplog: pytest.LogCaptureFixture
+    config_key: str, bad_value: str, expected_fragment: str
 ):
     """
     arrange: A single runner config option is set to an invalid value.
     act: Run config-changed.
-    assert: Unit status is Blocked with a short, stable message, and the
-        pydantic validation detail matching the expected fragment is logged
-        as a warning (Juju truncates status messages to their first line, so
-        the detail must go to the log instead).
+    assert: Unit status is Blocked with a message matching the expected fragment.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -746,19 +738,15 @@ def test_charm_blocked_invalid_runner_config(
     config[config_key] = bad_value
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
-    assert any(
-        record.levelname == "WARNING" and expected_fragment in record.message
-        for record in caplog.records
-    )
+    assert isinstance(out.unit_status, ops.BlockedStatus)
+    assert expected_fragment in out.unit_status.message
 
 
-def test_runner_config_aproxy_options_require_proxy(caplog: pytest.LogCaptureFixture):
+def test_runner_config_aproxy_options_require_proxy():
     """
     arrange: aproxy options set without runner-http-proxy.
     act: Run config-changed.
-    assert: Unit is Blocked — the aproxy options would otherwise silently no-op — and the
-        detail is logged as a warning.
+    assert: Unit is Blocked — the aproxy options would otherwise silently no-op.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -767,11 +755,8 @@ def test_runner_config_aproxy_options_require_proxy(caplog: pytest.LogCaptureFix
     config["aproxy-redirect-ports"] = "80,443"
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
-    assert any(
-        record.levelname == "WARNING" and "require runner-http-proxy to be set" in record.message
-        for record in caplog.records
-    )
+    assert isinstance(out.unit_status, ops.BlockedStatus)
+    assert "require runner-http-proxy to be set" in out.unit_status.message
 
 
 def test_runner_config_fields_written_to_garm_configurator_relation():

--- a/charms/garm-configurator/tests/unit/test_charm.py
+++ b/charms/garm-configurator/tests/unit/test_charm.py
@@ -154,11 +154,14 @@ _MISSING_CONFIG_SENTINEL = object()
         ),
     ],
 )
-def test_charm_blocked_invalid_config(config_mutations: dict, expected_message: str):
+def test_charm_blocked_invalid_config(
+    config_mutations: dict, expected_message: str, caplog: pytest.LogCaptureFixture
+):
     """
     arrange: Config is invalid (missing, empty, or has an invalid value).
     act: Run config-changed.
-    assert: Unit status is Blocked with the expected message.
+    assert: Unit status is Blocked with a short, stable message, and the
+        specific validation detail is logged as a warning.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -171,14 +174,19 @@ def test_charm_blocked_invalid_config(config_mutations: dict, expected_message: 
             config[key] = value
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus(expected_message)
+    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
+    assert any(
+        record.levelname == "WARNING" and expected_message in record.message
+        for record in caplog.records
+    )
 
 
-def test_charm_blocked_password_secret_missing_value_key():
+def test_charm_blocked_password_secret_missing_value_key(caplog: pytest.LogCaptureFixture):
     """
     arrange: openstack-password secret exists but lacks 'value' key.
     act: Run config-changed.
-    assert: Unit status is Blocked.
+    assert: Unit status is Blocked with a short message, and the specific
+        detail is logged as a warning.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = Secret(tracked_content={"wrong-key": "data"})
@@ -186,16 +194,20 @@ def test_charm_blocked_password_secret_missing_value_key():
     config = _valid_config(secret, pk_secret)
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus(
-        "openstack-password secret is invalid or missing 'value' key"
+    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
+    assert any(
+        record.levelname == "WARNING"
+        and "openstack-password secret is invalid or missing 'value' key" in record.message
+        for record in caplog.records
     )
 
 
-def test_charm_blocked_password_secret_not_found():
+def test_charm_blocked_password_secret_not_found(caplog: pytest.LogCaptureFixture):
     """
     arrange: openstack-password references a secret that doesn't exist in state.
     act: Run config-changed.
-    assert: Unit status is Blocked.
+    assert: Unit status is Blocked with a short message, and the specific
+        detail is logged as a warning.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -203,8 +215,11 @@ def test_charm_blocked_password_secret_not_found():
     config = _valid_config(secret, pk_secret)
     state = State(config=config, secrets=[pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus(
-        "openstack-password secret is invalid or missing 'value' key"
+    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
+    assert any(
+        record.levelname == "WARNING"
+        and "openstack-password secret is invalid or missing 'value' key" in record.message
+        for record in caplog.records
     )
 
 
@@ -224,11 +239,14 @@ def test_charm_not_blocked_with_http_auth_url():
     assert not isinstance(out.unit_status, ops.BlockedStatus)
 
 
-def test_charm_blocked_github_app_private_key_secret_missing_value_key():
+def test_charm_blocked_github_app_private_key_secret_missing_value_key(
+    caplog: pytest.LogCaptureFixture,
+):
     """
     arrange: github-app-private-key secret exists but lacks 'value' key.
     act: Run config-changed.
-    assert: Unit status is Blocked.
+    assert: Unit status is Blocked with a short message, and the specific
+        detail is logged as a warning.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -236,16 +254,20 @@ def test_charm_blocked_github_app_private_key_secret_missing_value_key():
     config = _valid_config(secret, bad_pk_secret)
     state = State(config=config, secrets=[secret, bad_pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus(
-        "github-app-private-key secret is invalid or missing 'value' key"
+    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
+    assert any(
+        record.levelname == "WARNING"
+        and "github-app-private-key secret is invalid or missing 'value' key" in record.message
+        for record in caplog.records
     )
 
 
-def test_charm_blocked_github_app_private_key_secret_not_found():
+def test_charm_blocked_github_app_private_key_secret_not_found(caplog: pytest.LogCaptureFixture):
     """
     arrange: github-app-private-key references a secret not in state.
     act: Run config-changed.
-    assert: Unit status is Blocked.
+    assert: Unit status is Blocked with a short message, and the specific
+        detail is logged as a warning.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -253,8 +275,11 @@ def test_charm_blocked_github_app_private_key_secret_not_found():
     config = _valid_config(secret, pk_secret)
     state = State(config=config, secrets=[secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert out.unit_status == ops.BlockedStatus(
-        "github-app-private-key secret is invalid or missing 'value' key"
+    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
+    assert any(
+        record.levelname == "WARNING"
+        and "github-app-private-key secret is invalid or missing 'value' key" in record.message
+        for record in caplog.records
     )
 
 
@@ -637,6 +662,7 @@ def test_reconcile_writes_optional_scaleset_fields_to_garm_relation():
     )
     assert "repo" not in garm_out.local_unit_data
 
+
 @pytest.mark.parametrize(
     "config_key, bad_value, expected_fragment",
     [
@@ -703,12 +729,15 @@ def test_reconcile_writes_optional_scaleset_fields_to_garm_relation():
     ],
 )
 def test_charm_blocked_invalid_runner_config(
-    config_key: str, bad_value: str, expected_fragment: str
+    config_key: str, bad_value: str, expected_fragment: str, caplog: pytest.LogCaptureFixture
 ):
     """
     arrange: A single runner config option is set to an invalid value.
     act: Run config-changed.
-    assert: Unit status is Blocked with a message matching the expected fragment.
+    assert: Unit status is Blocked with a short, stable message, and the
+        pydantic validation detail matching the expected fragment is logged
+        as a warning (Juju truncates status messages to their first line, so
+        the detail must go to the log instead).
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -717,15 +746,19 @@ def test_charm_blocked_invalid_runner_config(
     config[config_key] = bad_value
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert isinstance(out.unit_status, ops.BlockedStatus)
-    assert expected_fragment in out.unit_status.message
+    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
+    assert any(
+        record.levelname == "WARNING" and expected_fragment in record.message
+        for record in caplog.records
+    )
 
 
-def test_runner_config_aproxy_options_require_proxy():
+def test_runner_config_aproxy_options_require_proxy(caplog: pytest.LogCaptureFixture):
     """
     arrange: aproxy options set without runner-http-proxy.
     act: Run config-changed.
-    assert: Unit is Blocked — the aproxy options would otherwise silently no-op.
+    assert: Unit is Blocked — the aproxy options would otherwise silently no-op — and the
+        detail is logged as a warning.
     """
     ctx = Context(GarmConfiguratorCharm)
     secret = _make_secret()
@@ -734,8 +767,11 @@ def test_runner_config_aproxy_options_require_proxy():
     config["aproxy-redirect-ports"] = "80,443"
     state = State(config=config, secrets=[secret, pk_secret])
     out = ctx.run(ctx.on.config_changed(), state)
-    assert isinstance(out.unit_status, ops.BlockedStatus)
-    assert "require runner-http-proxy to be set" in out.unit_status.message
+    assert out.unit_status == ops.BlockedStatus("Invalid charm config")
+    assert any(
+        record.levelname == "WARNING" and "require runner-http-proxy to be set" in record.message
+        for record in caplog.records
+    )
 
 
 def test_runner_config_fields_written_to_garm_configurator_relation():

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-08
+
+- `garm-configurator`: log the full config-validation error and show a short blocked status. Invalid configuration previously put the entire (often multi-line) validation error into the unit status, where Juju truncates it to an unhelpful first line and nothing reached `juju debug-log`. The charm now logs the full detail at warning level and sets a stable `Invalid charm config` status, so the specific problem is discoverable in the logs.
+
 ## 2026-07-06
 
 - `garm`: fix the application status freezing on a stale value. The charm wrote the unit status directly on its own reconcile paths, so the leader's application status was never refreshed and could stay stuck (for example showing `Waiting for pebble ready` while the unit was `active`). Status writes now go through the shared unit/application status helper so both stay in sync.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-07-08
 
-- `garm-configurator`: log the full config-validation error and show a short blocked status. Invalid configuration previously put the entire (often multi-line) validation error into the unit status, where Juju truncates it to an unhelpful first line and nothing reached `juju debug-log`. The charm now logs the full detail at warning level and sets a stable `Invalid charm config` status, so the specific problem is discoverable in the logs.
+- `garm-configurator`: log the full config-validation detail when configuration is invalid. Juju truncates the blocked unit status to its first line, so a multi-line validation error (for example from an invalid runner option) was not fully visible. The charm now also logs the complete detail at warning level, so it is discoverable in `juju debug-log`.
 
 ## 2026-07-06
 


### PR DESCRIPTION
#### What this PR does

When config validation fails, `garm-configurator` put the entire pydantic `ValidationError` (often multi-line) straight into the unit status message. Juju truncates status messages to their first line, so operators only ever saw the generic header (e.g. `1 validation error for RunnerConfig`) with no field/reason, and nothing reached `juju debug-log`.

This aligns the charm with its siblings (`planner-operator`, `webhook-gateway-operator`): the full detail is logged at **warning** level, and the status is a short, stable `Invalid charm config`. `warning` (not `error`) is used because `_reconcile` runs on every event, so a persistently misconfigured charm would otherwise spam error-level logs.

#### Why we need it

The truncated status was actively misleading — an operator hitting an invalid runner option had no way to see which option or why without dumping `juju status --format=yaml`. The actionable detail now lives in `debug-log` where operators expect it.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) <!-- n/a: no process change -->
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) <!-- n/a: only changelog.md, no prose docs -->
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration <!-- n/a: unit-only -->
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard <!-- n/a -->
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors <!-- n/a -->
- [ ] **If this PR involves Rockcraft:** I updated the version <!-- n/a -->
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md` <!-- n/a: no convention change -->
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked the `AGENTS.md` "12-factor divergences" guidance <!-- n/a -->

#### Test plan

- `tox -c tox.toml -e fmt lint static unit` all pass in `charms/garm-configurator` (unit: 51/51).
- Existing invalid-config unit tests (Scenario-based) were updated: they now assert the short `Invalid charm config` status **and** that the specific validation detail is emitted as a WARNING log record (via `caplog`). No parallel tests were added — existing ones were extended.

#### Review focus

- The status message for *all* `CharmConfigInvalidError` paths (not just `RunnerConfig`) collapses to the single generic `Invalid charm config`. This is intentional, but reviewers may want to confirm that losing the per-cause status text (e.g. `Missing required configuration: openstack-auth-url`) is acceptable — that detail now lives only in the log. If a shorter *cause-specific* status is preferred, that's a larger change to how `CharmConfigInvalidError.msg` is structured.

#### Potential breaking changes / new dependencies

None. No new dependencies, APIs, or config options. Behavioral change is limited to status text + log output.