### PR TITLE
fix(garm): build openstack provider as static binary

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-08
+
+- Fix runner provisioning in the GARM workload: the OpenStack provider binary in the bare-base rock was built dynamically linked, so GARM could not execute it (`fork/exec /usr/local/bin/garm-provider-openstack: no such file or directory`) and no runners were spawned, even though the charm reported `active`. The provider is now built as a fully static, pure-Go binary, matching the GARM binary.
+
 ## 2026-07-06
 
 - `garm`: fix the application status freezing on a stale value. The charm wrote the unit status directly on its own reconcile paths, so the leader's application status was never refreshed and could stay stuck (for example showing `Waiting for pebble ready` while the unit was `active`). Status writes now go through the shared unit/application status helper so both stay in sync.

--- a/garm-rockcraft.yaml
+++ b/garm-rockcraft.yaml
@@ -43,9 +43,15 @@ parts:
       - go/1.26/stable
     build-environment:
       - GOTOOLCHAIN: local
+      # Force a fully static, pure-Go binary. The bare base ships no dynamic
+      # loader or libc, so a cgo/dynamically-linked binary fails at fork/exec
+      # with "no such file or directory" (missing ELF interpreter). CGO_ENABLED=0
+      # selects the pure-Go net/os resolvers, mirroring the garm part's
+      # osusergo,netgo,-static build.
+      - CGO_ENABLED: "0"
     override-build: |
       cd "$CRAFT_PART_SRC"
-      go build -ldflags "-extldflags -static" -o bin/garm-provider-openstack .
+      go build -o bin/garm-provider-openstack .
       mkdir -p "$CRAFT_PART_INSTALL/usr/local/bin"
       cp bin/garm-provider-openstack "$CRAFT_PART_INSTALL/usr/local/bin/"
 


### PR DESCRIPTION
#### What this PR does

Builds the `garm-provider-openstack` binary in the GARM rock with `CGO_ENABLED=0` so it is a fully static, pure-Go binary, and drops the ineffective `-extldflags -static` ldflag.

#### Why we need it

On the deployed `garm` charm, runner consolidation failed with:

```
provider binary /usr/local/bin/garm-provider-openstack ... fork/exec: no such file or directory
```

The binary was present but **dynamically linked**: with cgo enabled (default) and the `net` package imported, Go links glibc's NSS resolvers dynamically via its *internal* linker, which never invokes the external linker — so the existing `-extldflags -static` was silently ignored. The rock uses a `bare` base with no dynamic loader/libc, so GARM could not `exec` it and **no runners were spawned — while the charm still reported `active`** (the charm doesn't scrape GARM's runtime logs). The `garm` binary avoids this via its `osusergo,netgo` tags; the provider had neither those nor `CGO_ENABLED=0`.

#### Test plan

- Reproduced the original build locally (`go build -ldflags "-extldflags -static"`, cgo default) → `dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2`.
- Verified the fix (`CGO_ENABLED=0 go build`) → `statically linked`, **no ELF interpreter**.
- Rebuilt the rock end-to-end (`build-garm-rock.sh`), extracted the provider from the OCI layer → confirmed `statically linked`, no interp.

#### Review focus

- Chose `CGO_ENABLED=0` over adding `osusergo,netgo` tags: the OpenStack provider is pure Go with no cgo dependency (unlike garm's sqlite), so disabling cgo outright is the simplest guarantee and removes any reliance on the external linker honouring `-static`.

#### Potential breaking changes / new dependencies

None. Build-only change; no new modules, APIs, or workflow changes.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — N/A
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — N/A, only a changelog entry
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration) — N/A; static-linking is a rock build property with no charm-level test surface
- [ ] **If integration test modules are used:** I updated the workflow configuration — N/A
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard — N/A
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors — N/A
- [ ] **If this PR involves Rockcraft:** I updated the version — the garm rock version is static at `0.1` and prior rock fixes (e.g. #257) did not bump it; left unchanged for consistency
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md` — N/A
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked whether the `AGENTS.md` "12-factor divergences" guidance still matches the upstream copilot-collections guidance — N/A
