### PR TITLE
chore(ci): pin charm-ci/opcli to v0.0.1-alpha.7

### DIFF
--- a/.github/workflows/charms_integration.yaml
+++ b/.github/workflows/charms_integration.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   integration-test:
-    uses: canonical/charm-ci/.github/workflows/integration-test.yml@main
+    uses: canonical/charm-ci/.github/workflows/integration-test.yml@v0.0.1-alpha.7
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/publish_charms.yml
+++ b/.github/workflows/publish_charms.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   publish:
-    uses: canonical/charm-ci/.github/workflows/publish-artifacts.yml@main
+    uses: canonical/charm-ci/.github/workflows/publish-artifacts.yml@v0.0.1-alpha.7
     permissions:
       actions: read
       contents: write

--- a/spread.yaml
+++ b/spread.yaml
@@ -13,7 +13,7 @@ backends:
           disk: 20
 environment:
   CONCIERGE: '$(HOST: echo "${CONCIERGE:-concierge.yaml}")'
-  OPCLI_GIT_REF: '$(HOST: echo "${OPCLI_GIT_REF:-main}")'
+  OPCLI_GIT_REF: '$(HOST: echo "${OPCLI_GIT_REF:-v0.0.1-alpha.7}")'
   TEST_GITHUB_APP_ID: '$(HOST: echo "${TEST_GITHUB_APP_ID:-}")'
   TEST_GITHUB_APP_INSTALLATION_ID: '$(HOST: echo "${TEST_GITHUB_APP_INSTALLATION_ID:-}")'
   TEST_GITHUB_APP_PRIVATE_KEY: '$(HOST: echo "${TEST_GITHUB_APP_PRIVATE_KEY:-}")'

--- a/tox.ini
+++ b/tox.ini
@@ -103,7 +103,7 @@ description = Run combined charm integration tests
 set_env =
     PYTHONPATH = {tox_root}/charms
 deps =
-    opcli @ git+https://github.com/canonical/charm-ci.git@main
+    opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.7
     -r {[vars]tests_path}/integration/requirements.txt
 commands =
     pytest -v \


### PR DESCRIPTION
#### What this PR does

Pins every floating `@main` reference to `canonical/charm-ci` / `opcli` to the tagged release **`v0.0.1-alpha.7`**:

- `.github/workflows/publish_charms.yml` — `publish-artifacts.yml`
- `.github/workflows/charms_integration.yaml` — `integration-test.yml`
- `tox.ini` — `opcli @ git+…/charm-ci.git`
- `spread.yaml` — `OPCLI_GIT_REF` default

#### Why we need it

We should pin to a released version instead of tracking `@main`. Floating on `@main` means every charm-ci push silently changes our publish and integration tooling, with no control over when we pick up a change — as we just saw when `Publish to edge` broke without anything changing on our side (charmcraft 4.3.0 started hard-failing `charmcraft upload` on the experimental `go-framework` charms). Pinning to `v0.0.1-alpha.7` gives us a reproducible, reviewable version that only moves when we bump it deliberately. All four refs (both reusable workflows, the pip dependency, and the spread env) are verified to resolve at the tag.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process — N/A, version pin only
- [ ] Technical author assigned for documentation changes — N/A
- [ ] I updated `docs/changelog.md` with user-relevant changes — N/A, CI-tooling change with no user-facing effect
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests — N/A
- [ ] **If integration test modules are used:** I updated the workflow configuration — N/A, only the reusable-workflow ref changed, not the modules list
- [ ] **If this PR involves a Grafana dashboard:** screenshot — N/A
- [ ] **If this PR involves Terraform:** fmt/tflint — N/A
- [ ] **If this PR involves Rockcraft:** version bump — N/A
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** AGENTS.md — N/A
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** re-checked AGENTS.md 12-factor divergences — N/A
