### PR TITLE
fix(garm): resolve proxy host and configure snapd proxy before installing aproxy

### DIFF
--- a/charms/garm/src/templates/aproxy.j2
+++ b/charms/garm/src/templates/aproxy.j2
@@ -1,3 +1,15 @@
+# Resolve the proxy hostname to /etc/hosts so aproxy can reach the upstream
+# proxy before the transparent nftables redirect is active. This mirrors the
+# pattern used in the pre-job hook script for runner jobs.
+_aproxy_proxy_host=$(echo {{ proxy }} | sed 's|.*://||' | cut -d: -f1)
+_aproxy_host_entry=$(getent hosts "$_aproxy_proxy_host" 2>/dev/null | head -n 1)
+if [ -n "$_aproxy_host_entry" ]; then
+    echo "$_aproxy_host_entry" >> /etc/hosts
+fi
+# Configure snapd to download aproxy through the HTTP proxy in environments
+# where the snap store is not directly reachable.
+snap set system proxy.http={{ proxy }}
+snap set system proxy.https={{ proxy }}
 # Transparently forward runner egress through the configured HTTP proxy.
 snap install aproxy --edge
 snap set aproxy proxy={{ proxy }} listen=:54969

--- a/charms/garm/tests/unit/test_runner_template.py
+++ b/charms/garm/tests/unit/test_runner_template.py
@@ -49,6 +49,13 @@ def test_build_template_data_injects_all_options():
 
     # aproxy: correct listen port, nftables file (not a piped `nft -f -`), and
     # both the prerouting and output DNAT chains.
+    # aproxy bootstrap: proxy hostname resolved into /etc/hosts before snap
+    # installs aproxy, and snapd is told to use the proxy so the snap store is
+    # reachable even when there is no direct internet path.
+    assert "getent hosts" in result
+    assert "snap set system proxy.http" in result
+    assert "snap set system proxy.https" in result
+
     assert "listen=:54969" in result
     assert "default-ipv4" in result
     assert "/etc/nftables.conf" in result


### PR DESCRIPTION
#### What this PR does

Adds two steps at the top of the aproxy pre-install block (runs before `set -e` is active) in `aproxy.j2`:

1. **Resolve the proxy hostname into `/etc/hosts`** using `getent hosts`, so aproxy can reach the upstream proxy (`egress.ps7.internal`) as soon as the snap starts. This mirrors the pattern already used in the pre-job hook script for running jobs.
2. **Configure snapd to use the HTTP proxy** (`snap set system proxy.http/https`) so that `snap install aproxy --edge` succeeds in environments where the snap store is not directly reachable without a proxy.

#### Why we need it

Runner VMs fail to register with GARM because every outbound connection times out for ~134 s per attempt:

```
curl: (28) Failed to connect to garm-ps7.pfe.canonical.com port 443 after 134258 ms: Couldn't connect to server
```

Root cause: aproxy is installed successfully, but it cannot forward connections because `egress.ps7.internal` (the upstream HTTP proxy) is not resolvable via DNS at bootstrap time and is absent from `/etc/hosts`. The pre-job hook already patches this per-job, but the bootstrap phase had no equivalent step.

A secondary symptom is cloud-init package upgrade failures (`security.ubuntu.com` unreachable before any proxy is active), which are a WARNING and don't block the runner — the primary blocking issue is the GARM registration failure.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run)
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR involves Rockcraft:** I updated the version
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md`
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked whether the `AGENTS.md` "12-factor divergences" guidance still matches the upstream copilot-collections guidance

#### Test plan

All 9 existing `test_runner_template.py` unit tests pass. Added assertions to `test_build_template_data_injects_all_options` that verify the rendered template includes the proxy host DNS resolution step (`getent hosts`) and the snapd proxy configuration (`snap set system proxy.http/https`).

#### Review focus

- The new steps run before `set -e` (they are in the pre-install injection, before the base template's `set -e`), so a DNS failure (empty `getent hosts` result) is gracefully ignored rather than aborting the install.
- The snapd proxy config persists after aproxy's nftables redirect is active. This is harmless: snapd connects directly to `egress.ps7.internal:3128` (a private IP in the aproxy exclude list), so there is no double-proxying.