### PR TITLE
fix(garm): bump client pin to fix provider_fault deserialization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ charms — there are four charms, not two).
 - **`actions/` Python** — `tox -e actions-lint`, `tox -e actions-static`, `tox -e actions-unit`.
 - **Go** — `go test ./...`.
 - `charmcraft pack` — build a charm (run from the charm dir; not wired into tox).
+- **Docs spellcheck** — CI runs Vale over `docs/` with `Canonical.000-US-spellcheck` at **error** level, so an unknown technical term (e.g. `deserialize`) fails the build. Add project-specific terms — regex forms like `[Dd]eserializ(e|es|ed|ing|ation)` are supported — to `docs/.custom_wordlist.txt` (the docs `Makefile` appends it to the Canonical accept vocabulary); verify with `make -C docs spellcheck` before pushing a `docs/` change.
 - Gates from `CONTRIBUTING.md`: **≥ 85% coverage** on internal packages, **cyclomatic complexity < 10** per function.
 
 ## Charm conventions

--- a/charms/garm/AGENTS.md
+++ b/charms/garm/AGENTS.md
@@ -22,11 +22,13 @@ charm conventions; this file lists only what's specific to `garm`.
     reconciler modules import these types; **DO** keep `charm_state.py` free of
     rendering/reconciler imports so it can't form an import cycle.
 - **`src/garm_client/` is generated** by `scripts/generate_client.sh` (openapi-generator) —
-  **DON'T** hand-edit it. The script **patches the GARM swagger spec** before generating so
-  the template `data` field (Go `[]byte`, base64 string on the wire) becomes `StrictStr`
-  instead of `List[int]` (GARM issue #796); accordingly `garm_api.py` base64-encodes `data`
-  on create/update. To fix a generated-type issue, change the patch step and re-run, never
-  the output.
+  **DON'T** hand-edit it. The pin (`GARM_COMMIT`) is at a GARM revision that includes upstream's
+  `swagger:strfmt byte` fix (GARM PR #802), so Go `[]byte` fields — the template `data` body and
+  `GithubApp.private_key_bytes` — are declared `type: string, format: byte` in the spec and
+  generate as base64 strings directly; no local swagger patch is needed. Accordingly
+  `garm_api.py` base64-encodes `data` on create/update, and `charm.py` base64-encodes
+  `private_key_bytes` when building a `CredentialSpec`. To fix a generated-type issue, bump
+  `GARM_COMMIT` and re-run the script, never hand-edit the output.
 - GARM serves its API and `/metrics` on one fixed port (`GARM_PORT`); the `app-port` /
   `metrics-port` / `metrics-path` config options have no effect (the charm logs a warning
   rather than blocking). The port is pinned in the `_workload_config` property.

--- a/charms/garm/AGENTS.md
+++ b/charms/garm/AGENTS.md
@@ -25,10 +25,11 @@ charm conventions; this file lists only what's specific to `garm`.
   **DON'T** hand-edit it. The pin (`GARM_COMMIT`) is at a GARM revision that includes upstream's
   `swagger:strfmt byte` fix (GARM PR #802), so Go `[]byte` fields — the template `data` body and
   `GithubApp.private_key_bytes` — are declared `type: string, format: byte` in the spec and
-  generate as base64 strings directly; no local swagger patch is needed. Accordingly
-  `garm_api.py` base64-encodes `data` on create/update, and `charm.py` base64-encodes
-  `private_key_bytes` when building a `CredentialSpec`. To fix a generated-type issue, bump
-  `GARM_COMMIT` and re-run the script, never hand-edit the output.
+  generate as base64 strings directly; no local swagger patch is needed. These base64 strings
+  are produced at the API boundary: `garm_api.py` base64-encodes `data` on create/update, and
+  `github_reconciler.py` base64-encodes the raw PEM private key (held as `CredentialSpec.private_key`)
+  when building the `GithubApp` model. To fix a generated-type issue, bump `GARM_COMMIT` and
+  re-run the script, never hand-edit the output.
 - GARM serves its API and `/metrics` on one fixed port (`GARM_PORT`); the `app-port` /
   `metrics-port` / `metrics-path` config options have no effect (the charm logs a warning
   rather than blocking). The port is pinned in the `_workload_config` property.

--- a/charms/garm/scripts/generate_client.sh
+++ b/charms/garm/scripts/generate_client.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-GARM_COMMIT="47811d0046a9515085b85d88038f87ac68fd793c"
+GARM_COMMIT="fd712c653c114ddb4bf10e88e0214527b10e9f6f"
 SWAGGER_URL="https://raw.githubusercontent.com/cloudbase/garm/${GARM_COMMIT}/webapp/swagger.yaml"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
@@ -21,62 +21,12 @@ PACKAGE_DIR="${OUTPUT_DIR}/garm_client"
 echo "Downloading swagger.yaml from commit ${GARM_COMMIT}..."
 curl -fsSL "${SWAGGER_URL}" -o /tmp/garm_swagger.yaml
 
-# Patch the spec before generation. GARM renders the template `data` body (a Go []byte)
-# as `type: array, items: {type: integer, format: uint8}`, but the actual JSON wire format
-# is a base64 string. Rewrite the `data` property of the three template models to
-# `type: string` so the generated client uses StrictStr instead of List[int].
-# See https://github.com/cloudbase/garm/issues/796.
-# Scoped to template models on purpose: other []byte fields (e.g. private_key_bytes) are
-# still consumed as int-arrays elsewhere in the charm and must not be touched here.
-echo 'Patching template data (uint8-array) properties to strings...'
-python3 - /tmp/garm_swagger.yaml /tmp/garm_swagger.patched.yaml <<'PY'
-import sys
-import yaml
-
-src, dst = sys.argv[1], sys.argv[2]
-with open(src) as fh:
-    spec = yaml.safe_load(fh)
-
-TARGETS = ["Template", "CreateTemplateParams", "UpdateTemplateParams"]
-
-
-def is_uint8_array(schema):
-    if not isinstance(schema, dict) or schema.get("type") != "array":
-        return False
-    items = schema.get("items")
-    return (
-        isinstance(items, dict)
-        and items.get("type") == "integer"
-        and items.get("format") == "uint8"
-    )
-
-
-definitions = spec.get("definitions") or {}
-patched = 0
-for name in TARGETS:
-    schema = (definitions.get(name) or {}).get("properties", {}).get("data")
-    if not is_uint8_array(schema):
-        raise SystemExit(
-            f"{name}.data is not a uint8-array; spec may have changed, review the patch."
-        )
-    new_schema = {"type": "string"}
-    if "x-go-name" in schema:
-        new_schema["x-go-name"] = schema["x-go-name"]
-    definitions[name]["properties"]["data"] = new_schema
-    patched += 1
-
-print(f"Patched the data field of {patched} template model(s) to strings.")
-
-with open(dst, "w") as fh:
-    yaml.safe_dump(spec, fh, sort_keys=True)
-PY
-
 echo "Cleaning previous output at ${PACKAGE_DIR}..."
 rm -rf "${PACKAGE_DIR}"
 
 echo "Running openapi-generator-cli via Docker..."
 docker run --rm \
-    -v /tmp/garm_swagger.patched.yaml:/swagger.yaml:ro \
+    -v /tmp/garm_swagger.yaml:/swagger.yaml:ro \
     -v "${OUTPUT_DIR}":/output \
     openapitools/openapi-generator-cli:v7.23.0 generate \
     --input-spec /swagger.yaml \

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -4,6 +4,7 @@
 
 """GARM charm entrypoint."""
 
+import base64
 import dataclasses
 import hashlib
 import json
@@ -883,7 +884,7 @@ class GarmCharm(paas_charm.go.Charm):
                     endpoint=DEFAULT_GITHUB_ENDPOINT,
                     app_id=app_id,
                     installation_id=installation_id,
-                    private_key_bytes=list(private_key.encode()),
+                    private_key_bytes=base64.b64encode(private_key.encode()).decode("utf-8"),
                     description=MANAGED_CREDENTIAL_DESCRIPTION,
                 )
 

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -4,7 +4,6 @@
 
 """GARM charm entrypoint."""
 
-import base64
 import dataclasses
 import hashlib
 import json
@@ -884,7 +883,7 @@ class GarmCharm(paas_charm.go.Charm):
                     endpoint=DEFAULT_GITHUB_ENDPOINT,
                     app_id=app_id,
                     installation_id=installation_id,
-                    private_key_bytes=base64.b64encode(private_key.encode()).decode("utf-8"),
+                    private_key=private_key,
                     description=MANAGED_CREDENTIAL_DESCRIPTION,
                 )
 

--- a/charms/garm/src/garm_client/docs/ControllerInfo.md
+++ b/charms/garm/src/garm_client/docs/ControllerInfo.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **agent_url** | **str** | AgentURL is the URL where the GARM agent will connect. If set behind a reverse proxy, this URL must be configured to allow websocket connections. | [optional] 
-**ca_cert_bundle** | **List[int]** | CACertBundle holds a certificate bundle meant to validate the certificate used by GARM itself. This can be just the root certificate that can validate the GARM TLS certificate, a chain or multiple root CAs. | [optional] 
+**ca_cert_bundle** | **bytes** | CACertBundle holds a certificate bundle meant to validate the certificate used by GARM itself. This can be just the root certificate that can validate the GARM TLS certificate, a chain or multiple root CAs. | [optional] 
 **cached_garm_agent_release_fetched_at** | **datetime** | CachedGARMAgentReleaseFetchedAt is the timestamp when the release data was last fetched from GARMAgentReleasesURL | [optional] 
 **callback_url** | **str** | CallbackURL is the URL where instances can send updates back to the controller. This URL is used by instances to send status updates back to the controller. The URL itself may be made available to instances via a reverse proxy or a load balancer. That means that the user is responsible for telling GARM what the public URL is, by setting this field. | [optional] 
 **controller_id** | **UUID** | ControllerID is the unique ID of this controller. This ID gets generated automatically on controller init. | [optional] 

--- a/charms/garm/src/garm_client/docs/CreateGiteaEndpointParams.md
+++ b/charms/garm/src/garm_client/docs/CreateGiteaEndpointParams.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **api_base_url** | **str** |  | [optional] 
 **base_url** | **str** |  | [optional] 
-**ca_cert_bundle** | **List[int]** |  | [optional] 
+**ca_cert_bundle** | **bytes** |  | [optional] 
 **description** | **str** |  | [optional] 
 **name** | **str** |  | [optional] 
 **tools_metadata_url** | **str** |  | [optional] 

--- a/charms/garm/src/garm_client/docs/CreateGithubEndpointParams.md
+++ b/charms/garm/src/garm_client/docs/CreateGithubEndpointParams.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **api_base_url** | **str** |  | [optional] 
 **base_url** | **str** |  | [optional] 
-**ca_cert_bundle** | **List[int]** |  | [optional] 
+**ca_cert_bundle** | **bytes** |  | [optional] 
 **description** | **str** |  | [optional] 
 **name** | **str** |  | [optional] 
 **upload_base_url** | **str** |  | [optional] 

--- a/charms/garm/src/garm_client/docs/CreateTemplateParams.md
+++ b/charms/garm/src/garm_client/docs/CreateTemplateParams.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**data** | **str** |  | [optional] 
+**data** | **bytes** |  | [optional] 
 **description** | **str** |  | [optional] 
 **forge_type** | **str** |  | [optional] 
 **name** | **str** |  | [optional] 

--- a/charms/garm/src/garm_client/docs/ForgeCredentials.md
+++ b/charms/garm/src/garm_client/docs/ForgeCredentials.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **api_base_url** | **str** |  | [optional] 
 **auth_type** | **str** |  | [optional] 
 **base_url** | **str** |  | [optional] 
-**ca_bundle** | **List[int]** |  | [optional] 
+**ca_bundle** | **bytes** |  | [optional] 
 **created_at** | **datetime** |  | [optional] 
 **description** | **str** |  | [optional] 
 **endpoint** | [**ForgeEndpoint**](ForgeEndpoint.md) |  | [optional] 

--- a/charms/garm/src/garm_client/docs/ForgeEndpoint.md
+++ b/charms/garm/src/garm_client/docs/ForgeEndpoint.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **api_base_url** | **str** |  | [optional] 
 **base_url** | **str** |  | [optional] 
-**ca_cert_bundle** | **List[int]** |  | [optional] 
+**ca_cert_bundle** | **bytes** |  | [optional] 
 **created_at** | **datetime** |  | [optional] 
 **description** | **str** |  | [optional] 
 **endpoint_type** | **str** |  | [optional] 

--- a/charms/garm/src/garm_client/docs/GithubApp.md
+++ b/charms/garm/src/garm_client/docs/GithubApp.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **app_id** | **int** |  | [optional] 
 **installation_id** | **int** |  | [optional] 
-**private_key_bytes** | **List[int]** |  | [optional] 
+**private_key_bytes** | **bytes** |  | [optional] 
 
 ## Example
 

--- a/charms/garm/src/garm_client/docs/Instance.md
+++ b/charms/garm/src/garm_client/docs/Instance.md
@@ -20,7 +20,7 @@ Name | Type | Description | Notes
 **os_type** | **str** |  | [optional] 
 **os_version** | **str** | OSVersion is the version of the operating system. | [optional] 
 **pool_id** | **str** | PoolID is the ID of the garm pool to which a runner belongs. | [optional] 
-**provider_fault** | **List[int]** | ProviderFault holds any error messages captured from the IaaS provider that is responsible for managing the lifecycle of the runner. | [optional] 
+**provider_fault** | **bytes** | ProviderFault holds any error messages captured from the IaaS provider that is responsible for managing the lifecycle of the runner. | [optional] 
 **provider_id** | **str** | PeoviderID is the unique ID the provider associated with the compute instance. We use this to identify the instance in the provider. | [optional] 
 **provider_name** | **str** | ProviderName is the name of the IaaS where the instance was created. | [optional] 
 **runner_status** | **str** |  | [optional] 

--- a/charms/garm/src/garm_client/docs/Template.md
+++ b/charms/garm/src/garm_client/docs/Template.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **created_at** | **datetime** |  | [optional] 
-**data** | **str** |  | [optional] 
+**data** | **bytes** |  | [optional] 
 **description** | **str** |  | [optional] 
 **forge_type** | **str** |  | [optional] 
 **id** | **int** |  | [optional] 

--- a/charms/garm/src/garm_client/docs/UpdateControllerParams.md
+++ b/charms/garm/src/garm_client/docs/UpdateControllerParams.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **agent_url** | **str** |  | [optional] 
-**ca_cert_bundle** | **List[int]** |  | [optional] 
+**ca_cert_bundle** | **bytes** |  | [optional] 
 **callback_url** | **str** |  | [optional] 
 **clear_ca_cert_bundle** | **bool** |  | [optional] 
 **enable_agent_tools_sync** | **bool** |  | [optional] 

--- a/charms/garm/src/garm_client/docs/UpdateGiteaEndpointParams.md
+++ b/charms/garm/src/garm_client/docs/UpdateGiteaEndpointParams.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **api_base_url** | **str** |  | [optional] 
 **base_url** | **str** |  | [optional] 
-**ca_cert_bundle** | **List[int]** |  | [optional] 
+**ca_cert_bundle** | **bytes** |  | [optional] 
 **description** | **str** |  | [optional] 
 **tools_metadata_url** | **str** |  | [optional] 
 **use_internal_tools_metadata** | **bool** |  | [optional] 

--- a/charms/garm/src/garm_client/docs/UpdateGithubEndpointParams.md
+++ b/charms/garm/src/garm_client/docs/UpdateGithubEndpointParams.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **api_base_url** | **str** |  | [optional] 
 **base_url** | **str** |  | [optional] 
-**ca_cert_bundle** | **List[int]** |  | [optional] 
+**ca_cert_bundle** | **bytes** |  | [optional] 
 **description** | **str** |  | [optional] 
 **upload_base_url** | **str** |  | [optional] 
 

--- a/charms/garm/src/garm_client/docs/UpdateTemplateParams.md
+++ b/charms/garm/src/garm_client/docs/UpdateTemplateParams.md
@@ -5,7 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**data** | **str** |  | [optional] 
+**data** | **bytes** |  | [optional] 
 **description** | **str** |  | [optional] 
 **name** | **str** |  | [optional] 
 

--- a/charms/garm/src/garm_client/models/controller_info.py
+++ b/charms/garm/src/garm_client/models/controller_info.py
@@ -18,8 +18,9 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from uuid import UUID
 from typing import Optional, Set
 from typing_extensions import Self
@@ -30,7 +31,7 @@ class ControllerInfo(BaseModel):
     ControllerInfo
     """ # noqa: E501
     agent_url: Optional[StrictStr] = Field(default=None, description="AgentURL is the URL where the GARM agent will connect. If set behind a reverse proxy, this URL must be configured to allow websocket connections.")
-    ca_cert_bundle: Optional[List[StrictInt]] = Field(default=None, description="CACertBundle holds a certificate bundle meant to validate the certificate used by GARM itself. This can be just the root certificate that can validate the GARM TLS certificate, a chain or multiple root CAs.")
+    ca_cert_bundle: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = Field(default=None, description="CACertBundle holds a certificate bundle meant to validate the certificate used by GARM itself. This can be just the root certificate that can validate the GARM TLS certificate, a chain or multiple root CAs.")
     cached_garm_agent_release_fetched_at: Optional[datetime] = Field(default=None, description="CachedGARMAgentReleaseFetchedAt is the timestamp when the release data was last fetched from GARMAgentReleasesURL")
     callback_url: Optional[StrictStr] = Field(default=None, description="CallbackURL is the URL where instances can send updates back to the controller. This URL is used by instances to send status updates back to the controller. The URL itself may be made available to instances via a reverse proxy or a load balancer. That means that the user is responsible for telling GARM what the public URL is, by setting this field.")
     controller_id: Optional[UUID] = Field(default=None, description="ControllerID is the unique ID of this controller. This ID gets generated automatically on controller init.")
@@ -43,6 +44,19 @@ class ControllerInfo(BaseModel):
     version: Optional[StrictStr] = Field(default=None, description="Version is the version of the GARM controller.")
     webhook_url: Optional[StrictStr] = Field(default=None, description="WebhookURL is the base URL where the controller will receive webhooks from github. When webhook management is used, this URL is used as a base to which the controller UUID is appended and which will receive the webhooks. The URL itself may be made available to instances via a reverse proxy or a load balancer. That means that the user is responsible for telling GARM what the public URL is, by setting this field.")
     __properties: ClassVar[List[str]] = ["agent_url", "ca_cert_bundle", "cached_garm_agent_release_fetched_at", "callback_url", "controller_id", "controller_webhook_url", "enable_agent_tools_sync", "garm_agent_releases_url", "hostname", "metadata_url", "minimum_job_age_backoff", "version", "webhook_url"]
+
+    @field_validator('ca_cert_bundle')
+    def ca_cert_bundle_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/create_gitea_endpoint_params.py
+++ b/charms/garm/src/garm_client/models/create_gitea_endpoint_params.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -29,12 +30,25 @@ class CreateGiteaEndpointParams(BaseModel):
     """ # noqa: E501
     api_base_url: Optional[StrictStr] = None
     base_url: Optional[StrictStr] = None
-    ca_cert_bundle: Optional[List[StrictInt]] = None
+    ca_cert_bundle: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     description: Optional[StrictStr] = None
     name: Optional[StrictStr] = None
     tools_metadata_url: Optional[StrictStr] = None
     use_internal_tools_metadata: Optional[StrictBool] = None
     __properties: ClassVar[List[str]] = ["api_base_url", "base_url", "ca_cert_bundle", "description", "name", "tools_metadata_url", "use_internal_tools_metadata"]
+
+    @field_validator('ca_cert_bundle')
+    def ca_cert_bundle_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/create_github_endpoint_params.py
+++ b/charms/garm/src/garm_client/models/create_github_endpoint_params.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -29,11 +30,24 @@ class CreateGithubEndpointParams(BaseModel):
     """ # noqa: E501
     api_base_url: Optional[StrictStr] = None
     base_url: Optional[StrictStr] = None
-    ca_cert_bundle: Optional[List[StrictInt]] = None
+    ca_cert_bundle: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     description: Optional[StrictStr] = None
     name: Optional[StrictStr] = None
     upload_base_url: Optional[StrictStr] = None
     __properties: ClassVar[List[str]] = ["api_base_url", "base_url", "ca_cert_bundle", "description", "name", "upload_base_url"]
+
+    @field_validator('ca_cert_bundle')
+    def ca_cert_bundle_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/create_template_params.py
+++ b/charms/garm/src/garm_client/models/create_template_params.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -27,12 +28,25 @@ class CreateTemplateParams(BaseModel):
     """
     CreateTemplateParams
     """ # noqa: E501
-    data: Optional[StrictStr] = None
+    data: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     description: Optional[StrictStr] = None
     forge_type: Optional[StrictStr] = None
     name: Optional[StrictStr] = None
     os_type: Optional[StrictStr] = None
     __properties: ClassVar[List[str]] = ["data", "description", "forge_type", "name", "os_type"]
+
+    @field_validator('data')
+    def data_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/forge_credentials.py
+++ b/charms/garm/src/garm_client/models/forge_credentials.py
@@ -18,8 +18,9 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from garm_client.models.forge_endpoint import ForgeEndpoint
 from garm_client.models.github_rate_limit import GithubRateLimit
 from typing import Optional, Set
@@ -33,7 +34,7 @@ class ForgeCredentials(BaseModel):
     api_base_url: Optional[StrictStr] = None
     auth_type: Optional[StrictStr] = Field(default=None, alias="auth-type")
     base_url: Optional[StrictStr] = None
-    ca_bundle: Optional[List[StrictInt]] = None
+    ca_bundle: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     created_at: Optional[datetime] = None
     description: Optional[StrictStr] = None
     endpoint: Optional[ForgeEndpoint] = None
@@ -47,6 +48,19 @@ class ForgeCredentials(BaseModel):
     updated_at: Optional[datetime] = None
     upload_base_url: Optional[StrictStr] = None
     __properties: ClassVar[List[str]] = ["api_base_url", "auth-type", "base_url", "ca_bundle", "created_at", "description", "endpoint", "enterprises", "forge_type", "id", "name", "organizations", "rate_limit", "repositories", "updated_at", "upload_base_url"]
+
+    @field_validator('ca_bundle')
+    def ca_bundle_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/forge_endpoint.py
+++ b/charms/garm/src/garm_client/models/forge_endpoint.py
@@ -18,8 +18,9 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -30,7 +31,7 @@ class ForgeEndpoint(BaseModel):
     """ # noqa: E501
     api_base_url: Optional[StrictStr] = None
     base_url: Optional[StrictStr] = None
-    ca_cert_bundle: Optional[List[StrictInt]] = None
+    ca_cert_bundle: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     created_at: Optional[datetime] = None
     description: Optional[StrictStr] = None
     endpoint_type: Optional[StrictStr] = None
@@ -40,6 +41,19 @@ class ForgeEndpoint(BaseModel):
     upload_base_url: Optional[StrictStr] = None
     use_internal_tools_metadata: Optional[StrictBool] = None
     __properties: ClassVar[List[str]] = ["api_base_url", "base_url", "ca_cert_bundle", "created_at", "description", "endpoint_type", "name", "tools_metadata_url", "updated_at", "upload_base_url", "use_internal_tools_metadata"]
+
+    @field_validator('ca_cert_bundle')
+    def ca_cert_bundle_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/github_app.py
+++ b/charms/garm/src/garm_client/models/github_app.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictInt
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -29,8 +30,21 @@ class GithubApp(BaseModel):
     """ # noqa: E501
     app_id: Optional[StrictInt] = None
     installation_id: Optional[StrictInt] = None
-    private_key_bytes: Optional[List[StrictInt]] = None
+    private_key_bytes: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     __properties: ClassVar[List[str]] = ["app_id", "installation_id", "private_key_bytes"]
+
+    @field_validator('private_key_bytes')
+    def private_key_bytes_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/instance.py
+++ b/charms/garm/src/garm_client/models/instance.py
@@ -18,8 +18,9 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from garm_client.models.address import Address
 from garm_client.models.agent_capabilities import AgentCapabilities
 from garm_client.models.job import Job
@@ -47,7 +48,7 @@ class Instance(BaseModel):
     os_type: Optional[StrictStr] = None
     os_version: Optional[StrictStr] = Field(default=None, description="OSVersion is the version of the operating system.")
     pool_id: Optional[StrictStr] = Field(default=None, description="PoolID is the ID of the garm pool to which a runner belongs.")
-    provider_fault: Optional[List[StrictInt]] = Field(default=None, description="ProviderFault holds any error messages captured from the IaaS provider that is responsible for managing the lifecycle of the runner.")
+    provider_fault: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = Field(default=None, description="ProviderFault holds any error messages captured from the IaaS provider that is responsible for managing the lifecycle of the runner.")
     provider_id: Optional[StrictStr] = Field(default=None, description="PeoviderID is the unique ID the provider associated with the compute instance. We use this to identify the instance in the provider.")
     provider_name: Optional[StrictStr] = Field(default=None, description="ProviderName is the name of the IaaS where the instance was created.")
     runner_status: Optional[StrictStr] = None
@@ -56,6 +57,19 @@ class Instance(BaseModel):
     status_messages: Optional[List[StatusMessage]] = Field(default=None, description="StatusMessages is a list of status messages sent back by the runner as it sets itself up.")
     updated_at: Optional[datetime] = Field(default=None, description="UpdatedAt is the timestamp of the last update to this runner.")
     __properties: ClassVar[List[str]] = ["addresses", "agent_id", "capabilities", "created_at", "generation", "github-runner-group", "heartbeat", "id", "job", "name", "os_arch", "os_name", "os_type", "os_version", "pool_id", "provider_fault", "provider_id", "provider_name", "runner_status", "scale_set_id", "status", "status_messages", "updated_at"]
+
+    @field_validator('provider_fault')
+    def provider_fault_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/template.py
+++ b/charms/garm/src/garm_client/models/template.py
@@ -18,8 +18,9 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -29,7 +30,7 @@ class Template(BaseModel):
     Template
     """ # noqa: E501
     created_at: Optional[datetime] = None
-    data: Optional[StrictStr] = None
+    data: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     description: Optional[StrictStr] = None
     forge_type: Optional[StrictStr] = None
     id: Optional[StrictInt] = None
@@ -38,6 +39,19 @@ class Template(BaseModel):
     owner_id: Optional[StrictStr] = None
     updated_at: Optional[datetime] = None
     __properties: ClassVar[List[str]] = ["created_at", "data", "description", "forge_type", "id", "name", "os_type", "owner_id", "updated_at"]
+
+    @field_validator('data')
+    def data_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/update_controller_params.py
+++ b/charms/garm/src/garm_client/models/update_controller_params.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -28,7 +29,7 @@ class UpdateControllerParams(BaseModel):
     UpdateControllerParams
     """ # noqa: E501
     agent_url: Optional[StrictStr] = None
-    ca_cert_bundle: Optional[List[StrictInt]] = None
+    ca_cert_bundle: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     callback_url: Optional[StrictStr] = None
     clear_ca_cert_bundle: Optional[StrictBool] = None
     enable_agent_tools_sync: Optional[StrictBool] = None
@@ -37,6 +38,19 @@ class UpdateControllerParams(BaseModel):
     minimum_job_age_backoff: Optional[StrictInt] = None
     webhook_url: Optional[StrictStr] = None
     __properties: ClassVar[List[str]] = ["agent_url", "ca_cert_bundle", "callback_url", "clear_ca_cert_bundle", "enable_agent_tools_sync", "garm_agent_releases_url", "metadata_url", "minimum_job_age_backoff", "webhook_url"]
+
+    @field_validator('ca_cert_bundle')
+    def ca_cert_bundle_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/update_gitea_endpoint_params.py
+++ b/charms/garm/src/garm_client/models/update_gitea_endpoint_params.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictBool, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -29,11 +30,24 @@ class UpdateGiteaEndpointParams(BaseModel):
     """ # noqa: E501
     api_base_url: Optional[StrictStr] = None
     base_url: Optional[StrictStr] = None
-    ca_cert_bundle: Optional[List[StrictInt]] = None
+    ca_cert_bundle: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     description: Optional[StrictStr] = None
     tools_metadata_url: Optional[StrictStr] = None
     use_internal_tools_metadata: Optional[StrictBool] = None
     __properties: ClassVar[List[str]] = ["api_base_url", "base_url", "ca_cert_bundle", "description", "tools_metadata_url", "use_internal_tools_metadata"]
+
+    @field_validator('ca_cert_bundle')
+    def ca_cert_bundle_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/update_github_endpoint_params.py
+++ b/charms/garm/src/garm_client/models/update_github_endpoint_params.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -29,10 +30,23 @@ class UpdateGithubEndpointParams(BaseModel):
     """ # noqa: E501
     api_base_url: Optional[StrictStr] = None
     base_url: Optional[StrictStr] = None
-    ca_cert_bundle: Optional[List[StrictInt]] = None
+    ca_cert_bundle: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     description: Optional[StrictStr] = None
     upload_base_url: Optional[StrictStr] = None
     __properties: ClassVar[List[str]] = ["api_base_url", "base_url", "ca_cert_bundle", "description", "upload_base_url"]
+
+    @field_validator('ca_cert_bundle')
+    def ca_cert_bundle_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/models/update_template_params.py
+++ b/charms/garm/src/garm_client/models/update_template_params.py
@@ -17,8 +17,9 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr
-from typing import Any, ClassVar, Dict, List, Optional
+from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
+from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Annotated
 from typing import Optional, Set
 from typing_extensions import Self
 from pydantic_core import to_jsonable_python
@@ -27,10 +28,23 @@ class UpdateTemplateParams(BaseModel):
     """
     UpdateTemplateParams
     """ # noqa: E501
-    data: Optional[StrictStr] = None
+    data: Optional[Union[Annotated[bytes, Field(strict=True)], Annotated[str, Field(strict=True)]]] = None
     description: Optional[StrictStr] = None
     name: Optional[StrictStr] = None
     __properties: ClassVar[List[str]] = ["data", "description", "name"]
+
+    @field_validator('data')
+    def data_validate_regular_expression(cls, value):
+        """Validates the regular expression"""
+        if value is None:
+            return value
+
+        if not isinstance(value, str):
+            value = str(value)
+
+        if not re.match(r"^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$", value):
+            raise ValueError(r"must validate the regular expression /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/")
+        return value
 
     model_config = ConfigDict(
         validate_by_name=True,

--- a/charms/garm/src/garm_client/test/test_controller_info.py
+++ b/charms/garm/src/garm_client/test/test_controller_info.py
@@ -36,9 +36,7 @@ class TestControllerInfo(unittest.TestCase):
         if include_optional:
             return ControllerInfo(
                 agent_url = '',
-                ca_cert_bundle = [
-                    56
-                    ],
+                ca_cert_bundle = 'YQ==',
                 cached_garm_agent_release_fetched_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'),
                 callback_url = '',
                 controller_id = '',

--- a/charms/garm/src/garm_client/test/test_create_gitea_credentials_params.py
+++ b/charms/garm/src/garm_client/test/test_create_gitea_credentials_params.py
@@ -38,9 +38,7 @@ class TestCreateGiteaCredentialsParams(unittest.TestCase):
                 app = garm_client.models.github_app.GithubApp(
                     app_id = 56, 
                     installation_id = 56, 
-                    private_key_bytes = [
-                        56
-                        ], ),
+                    private_key_bytes = 'YQ==', ),
                 auth_type = '',
                 description = '',
                 endpoint = '',

--- a/charms/garm/src/garm_client/test/test_create_gitea_endpoint_params.py
+++ b/charms/garm/src/garm_client/test/test_create_gitea_endpoint_params.py
@@ -37,9 +37,7 @@ class TestCreateGiteaEndpointParams(unittest.TestCase):
             return CreateGiteaEndpointParams(
                 api_base_url = '',
                 base_url = '',
-                ca_cert_bundle = [
-                    56
-                    ],
+                ca_cert_bundle = 'YQ==',
                 description = '',
                 name = '',
                 tools_metadata_url = '',

--- a/charms/garm/src/garm_client/test/test_create_github_credentials_params.py
+++ b/charms/garm/src/garm_client/test/test_create_github_credentials_params.py
@@ -38,9 +38,7 @@ class TestCreateGithubCredentialsParams(unittest.TestCase):
                 app = garm_client.models.github_app.GithubApp(
                     app_id = 56, 
                     installation_id = 56, 
-                    private_key_bytes = [
-                        56
-                        ], ),
+                    private_key_bytes = 'YQ==', ),
                 auth_type = '',
                 description = '',
                 endpoint = '',

--- a/charms/garm/src/garm_client/test/test_create_github_endpoint_params.py
+++ b/charms/garm/src/garm_client/test/test_create_github_endpoint_params.py
@@ -37,9 +37,7 @@ class TestCreateGithubEndpointParams(unittest.TestCase):
             return CreateGithubEndpointParams(
                 api_base_url = '',
                 base_url = '',
-                ca_cert_bundle = [
-                    56
-                    ],
+                ca_cert_bundle = 'YQ==',
                 description = '',
                 name = '',
                 upload_base_url = ''

--- a/charms/garm/src/garm_client/test/test_create_template_params.py
+++ b/charms/garm/src/garm_client/test/test_create_template_params.py
@@ -35,7 +35,7 @@ class TestCreateTemplateParams(unittest.TestCase):
         model = CreateTemplateParams()
         if include_optional:
             return CreateTemplateParams(
-                data = '',
+                data = 'YQ==',
                 description = '',
                 forge_type = '',
                 name = '',

--- a/charms/garm/src/garm_client/test/test_enterprise.py
+++ b/charms/garm/src/garm_client/test/test_enterprise.py
@@ -41,17 +41,13 @@ class TestEnterprise(unittest.TestCase):
                     api_base_url = '', 
                     auth_type = '', 
                     base_url = '', 
-                    ca_bundle = [
-                        56
-                        ], 
+                    ca_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                         api_base_url = '', 
                         base_url = '', 
-                        ca_cert_bundle = [
-                            56
-                            ], 
+                        ca_cert_bundle = 'YQ==', 
                         created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                         description = '', 
                         endpoint_type = '', 
@@ -67,6 +63,7 @@ class TestEnterprise(unittest.TestCase):
                             credentials = garm_client.models.forge_credentials.ForgeCredentials(
                                 api_base_url = '', 
                                 base_url = '', 
+                                ca_bundle = 'YQ==', 
                                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                                 description = '', 
                                 forge_type = '', 
@@ -149,9 +146,7 @@ class TestEnterprise(unittest.TestCase):
                                                         os_type = '', 
                                                         os_version = '', 
                                                         pool_id = '', 
-                                                        provider_fault = [
-                                                            56
-                                                            ], 
+                                                        provider_fault = 'YQ==', 
                                                         provider_id = '', 
                                                         provider_name = '', 
                                                         runner_status = '', 
@@ -288,9 +283,7 @@ class TestEnterprise(unittest.TestCase):
                 endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                     api_base_url = '', 
                     base_url = '', 
-                    ca_cert_bundle = [
-                        56
-                        ], 
+                    ca_cert_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint_type = '', 
@@ -317,9 +310,7 @@ class TestEnterprise(unittest.TestCase):
                         endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                             api_base_url = '', 
                             base_url = '', 
-                            ca_cert_bundle = [
-                                56
-                                ], 
+                            ca_cert_bundle = 'YQ==', 
                             created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             description = '', 
                             endpoint_type = '', 
@@ -384,9 +375,7 @@ class TestEnterprise(unittest.TestCase):
                                 os_type = '', 
                                 os_version = '', 
                                 pool_id = '', 
-                                provider_fault = [
-                                    56
-                                    ], 
+                                provider_fault = 'YQ==', 
                                 provider_id = '', 
                                 provider_name = '', 
                                 runner_status = '', 

--- a/charms/garm/src/garm_client/test/test_forge_credentials.py
+++ b/charms/garm/src/garm_client/test/test_forge_credentials.py
@@ -38,17 +38,13 @@ class TestForgeCredentials(unittest.TestCase):
                 api_base_url = '',
                 auth_type = '',
                 base_url = '',
-                ca_bundle = [
-                    56
-                    ],
+                ca_bundle = 'YQ==',
                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'),
                 description = '',
                 endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                     api_base_url = '', 
                     base_url = '', 
-                    ca_cert_bundle = [
-                        56
-                        ], 
+                    ca_cert_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint_type = '', 
@@ -65,17 +61,13 @@ class TestForgeCredentials(unittest.TestCase):
                             api_base_url = '', 
                             auth_type = '', 
                             base_url = '', 
-                            ca_bundle = [
-                                56
-                                ], 
+                            ca_bundle = 'YQ==', 
                             created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             description = '', 
                             endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                                 api_base_url = '', 
                                 base_url = '', 
-                                ca_cert_bundle = [
-                                    56
-                                    ], 
+                                ca_cert_bundle = 'YQ==', 
                                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                                 description = '', 
                                 endpoint_type = '', 
@@ -164,9 +156,7 @@ class TestForgeCredentials(unittest.TestCase):
                                                     os_type = '', 
                                                     os_version = '', 
                                                     pool_id = '', 
-                                                    provider_fault = [
-                                                        56
-                                                        ], 
+                                                    provider_fault = 'YQ==', 
                                                     provider_id = '', 
                                                     provider_name = '', 
                                                     runner_status = '', 
@@ -231,6 +221,7 @@ class TestForgeCredentials(unittest.TestCase):
                         endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                             api_base_url = '', 
                             base_url = '', 
+                            ca_cert_bundle = 'YQ==', 
                             created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             description = '', 
                             name = '', 
@@ -290,17 +281,13 @@ class TestForgeCredentials(unittest.TestCase):
                             api_base_url = '', 
                             auth_type = '', 
                             base_url = '', 
-                            ca_bundle = [
-                                56
-                                ], 
+                            ca_bundle = 'YQ==', 
                             created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             description = '', 
                             endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                                 api_base_url = '', 
                                 base_url = '', 
-                                ca_cert_bundle = [
-                                    56
-                                    ], 
+                                ca_cert_bundle = 'YQ==', 
                                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                                 description = '', 
                                 endpoint_type = '', 
@@ -386,9 +373,7 @@ class TestForgeCredentials(unittest.TestCase):
                                                     os_type = '', 
                                                     os_version = '', 
                                                     pool_id = '', 
-                                                    provider_fault = [
-                                                        56
-                                                        ], 
+                                                    provider_fault = 'YQ==', 
                                                     provider_id = '', 
                                                     provider_name = '', 
                                                     runner_status = '', 
@@ -457,6 +442,7 @@ class TestForgeCredentials(unittest.TestCase):
                         endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                             api_base_url = '', 
                             base_url = '', 
+                            ca_cert_bundle = 'YQ==', 
                             created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             description = '', 
                             name = '', 
@@ -518,17 +504,13 @@ class TestForgeCredentials(unittest.TestCase):
                             api_base_url = '', 
                             auth_type = '', 
                             base_url = '', 
-                            ca_bundle = [
-                                56
-                                ], 
+                            ca_bundle = 'YQ==', 
                             created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             description = '', 
                             endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                                 api_base_url = '', 
                                 base_url = '', 
-                                ca_cert_bundle = [
-                                    56
-                                    ], 
+                                ca_cert_bundle = 'YQ==', 
                                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                                 description = '', 
                                 endpoint_type = '', 
@@ -614,9 +596,7 @@ class TestForgeCredentials(unittest.TestCase):
                                                     os_type = '', 
                                                     os_version = '', 
                                                     pool_id = '', 
-                                                    provider_fault = [
-                                                        56
-                                                        ], 
+                                                    provider_fault = 'YQ==', 
                                                     provider_id = '', 
                                                     provider_name = '', 
                                                     runner_status = '', 
@@ -684,6 +664,7 @@ class TestForgeCredentials(unittest.TestCase):
                         endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                             api_base_url = '', 
                             base_url = '', 
+                            ca_cert_bundle = 'YQ==', 
                             created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             description = '', 
                             name = '', 

--- a/charms/garm/src/garm_client/test/test_forge_endpoint.py
+++ b/charms/garm/src/garm_client/test/test_forge_endpoint.py
@@ -37,9 +37,7 @@ class TestForgeEndpoint(unittest.TestCase):
             return ForgeEndpoint(
                 api_base_url = '',
                 base_url = '',
-                ca_cert_bundle = [
-                    56
-                    ],
+                ca_cert_bundle = 'YQ==',
                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'),
                 description = '',
                 endpoint_type = '',

--- a/charms/garm/src/garm_client/test/test_forge_entity.py
+++ b/charms/garm/src/garm_client/test/test_forge_entity.py
@@ -41,17 +41,13 @@ class TestForgeEntity(unittest.TestCase):
                     api_base_url = '', 
                     auth_type = '', 
                     base_url = '', 
-                    ca_bundle = [
-                        56
-                        ], 
+                    ca_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                         api_base_url = '', 
                         base_url = '', 
-                        ca_cert_bundle = [
-                            56
-                            ], 
+                        ca_cert_bundle = 'YQ==', 
                         created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                         description = '', 
                         endpoint_type = '', 
@@ -68,6 +64,7 @@ class TestForgeEntity(unittest.TestCase):
                                 api_base_url = '', 
                                 auth_type = '', 
                                 base_url = '', 
+                                ca_bundle = 'YQ==', 
                                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                                 description = '', 
                                 forge_type = '', 
@@ -150,9 +147,7 @@ class TestForgeEntity(unittest.TestCase):
                                                         os_type = '', 
                                                         os_version = '', 
                                                         pool_id = '', 
-                                                        provider_fault = [
-                                                            56
-                                                            ], 
+                                                        provider_fault = 'YQ==', 
                                                         provider_id = '', 
                                                         provider_name = '', 
                                                         runner_status = '', 

--- a/charms/garm/src/garm_client/test/test_github_app.py
+++ b/charms/garm/src/garm_client/test/test_github_app.py
@@ -37,9 +37,7 @@ class TestGithubApp(unittest.TestCase):
             return GithubApp(
                 app_id = 56,
                 installation_id = 56,
-                private_key_bytes = [
-                    56
-                    ]
+                private_key_bytes = 'YQ=='
             )
         else:
             return GithubApp(

--- a/charms/garm/src/garm_client/test/test_instance.py
+++ b/charms/garm/src/garm_client/test/test_instance.py
@@ -81,9 +81,7 @@ class TestInstance(unittest.TestCase):
                 os_type = '',
                 os_version = '',
                 pool_id = '',
-                provider_fault = [
-                    56
-                    ],
+                provider_fault = 'YQ==',
                 provider_id = '',
                 provider_name = '',
                 runner_status = '',

--- a/charms/garm/src/garm_client/test/test_organization.py
+++ b/charms/garm/src/garm_client/test/test_organization.py
@@ -41,17 +41,13 @@ class TestOrganization(unittest.TestCase):
                     api_base_url = '', 
                     auth_type = '', 
                     base_url = '', 
-                    ca_bundle = [
-                        56
-                        ], 
+                    ca_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                         api_base_url = '', 
                         base_url = '', 
-                        ca_cert_bundle = [
-                            56
-                            ], 
+                        ca_cert_bundle = 'YQ==', 
                         created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                         description = '', 
                         endpoint_type = '', 
@@ -67,6 +63,7 @@ class TestOrganization(unittest.TestCase):
                             credentials = garm_client.models.forge_credentials.ForgeCredentials(
                                 api_base_url = '', 
                                 base_url = '', 
+                                ca_bundle = 'YQ==', 
                                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                                 description = '', 
                                 forge_type = '', 
@@ -149,9 +146,7 @@ class TestOrganization(unittest.TestCase):
                                                         os_type = '', 
                                                         os_version = '', 
                                                         pool_id = '', 
-                                                        provider_fault = [
-                                                            56
-                                                            ], 
+                                                        provider_fault = 'YQ==', 
                                                         provider_id = '', 
                                                         provider_name = '', 
                                                         runner_status = '', 
@@ -288,9 +283,7 @@ class TestOrganization(unittest.TestCase):
                 endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                     api_base_url = '', 
                     base_url = '', 
-                    ca_cert_bundle = [
-                        56
-                        ], 
+                    ca_cert_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint_type = '', 
@@ -317,9 +310,7 @@ class TestOrganization(unittest.TestCase):
                         endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                             api_base_url = '', 
                             base_url = '', 
-                            ca_cert_bundle = [
-                                56
-                                ], 
+                            ca_cert_bundle = 'YQ==', 
                             created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             description = '', 
                             endpoint_type = '', 
@@ -384,9 +375,7 @@ class TestOrganization(unittest.TestCase):
                                 os_type = '', 
                                 os_version = '', 
                                 pool_id = '', 
-                                provider_fault = [
-                                    56
-                                    ], 
+                                provider_fault = 'YQ==', 
                                 provider_id = '', 
                                 provider_name = '', 
                                 runner_status = '', 

--- a/charms/garm/src/garm_client/test/test_pool.py
+++ b/charms/garm/src/garm_client/test/test_pool.py
@@ -41,9 +41,7 @@ class TestPool(unittest.TestCase):
                 endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                     api_base_url = '', 
                     base_url = '', 
-                    ca_cert_bundle = [
-                        56
-                        ], 
+                    ca_cert_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint_type = '', 
@@ -108,9 +106,7 @@ class TestPool(unittest.TestCase):
                         os_type = '', 
                         os_version = '', 
                         pool_id = '', 
-                        provider_fault = [
-                            56
-                            ], 
+                        provider_fault = 'YQ==', 
                         provider_id = '', 
                         provider_name = '', 
                         runner_status = '', 

--- a/charms/garm/src/garm_client/test/test_repository.py
+++ b/charms/garm/src/garm_client/test/test_repository.py
@@ -41,17 +41,13 @@ class TestRepository(unittest.TestCase):
                     api_base_url = '', 
                     auth_type = '', 
                     base_url = '', 
-                    ca_bundle = [
-                        56
-                        ], 
+                    ca_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                         api_base_url = '', 
                         base_url = '', 
-                        ca_cert_bundle = [
-                            56
-                            ], 
+                        ca_cert_bundle = 'YQ==', 
                         created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                         description = '', 
                         endpoint_type = '', 
@@ -67,6 +63,7 @@ class TestRepository(unittest.TestCase):
                             credentials = garm_client.models.forge_credentials.ForgeCredentials(
                                 api_base_url = '', 
                                 base_url = '', 
+                                ca_bundle = 'YQ==', 
                                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                                 description = '', 
                                 forge_type = '', 
@@ -149,9 +146,7 @@ class TestRepository(unittest.TestCase):
                                                         os_type = '', 
                                                         os_version = '', 
                                                         pool_id = '', 
-                                                        provider_fault = [
-                                                            56
-                                                            ], 
+                                                        provider_fault = 'YQ==', 
                                                         provider_id = '', 
                                                         provider_name = '', 
                                                         runner_status = '', 
@@ -288,9 +283,7 @@ class TestRepository(unittest.TestCase):
                 endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                     api_base_url = '', 
                     base_url = '', 
-                    ca_cert_bundle = [
-                        56
-                        ], 
+                    ca_cert_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint_type = '', 
@@ -318,9 +311,7 @@ class TestRepository(unittest.TestCase):
                         endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                             api_base_url = '', 
                             base_url = '', 
-                            ca_cert_bundle = [
-                                56
-                                ], 
+                            ca_cert_bundle = 'YQ==', 
                             created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                             description = '', 
                             endpoint_type = '', 
@@ -385,9 +376,7 @@ class TestRepository(unittest.TestCase):
                                 os_type = '', 
                                 os_version = '', 
                                 pool_id = '', 
-                                provider_fault = [
-                                    56
-                                    ], 
+                                provider_fault = 'YQ==', 
                                 provider_id = '', 
                                 provider_name = '', 
                                 runner_status = '', 

--- a/charms/garm/src/garm_client/test/test_scale_set.py
+++ b/charms/garm/src/garm_client/test/test_scale_set.py
@@ -43,9 +43,7 @@ class TestScaleSet(unittest.TestCase):
                 endpoint = garm_client.models.forge_endpoint.ForgeEndpoint(
                     api_base_url = '', 
                     base_url = '', 
-                    ca_cert_bundle = [
-                        56
-                        ], 
+                    ca_cert_bundle = 'YQ==', 
                     created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
                     description = '', 
                     endpoint_type = '', 
@@ -111,9 +109,7 @@ class TestScaleSet(unittest.TestCase):
                         os_type = '', 
                         os_version = '', 
                         pool_id = '', 
-                        provider_fault = [
-                            56
-                            ], 
+                        provider_fault = 'YQ==', 
                         provider_id = '', 
                         provider_name = '', 
                         runner_status = '', 

--- a/charms/garm/src/garm_client/test/test_template.py
+++ b/charms/garm/src/garm_client/test/test_template.py
@@ -36,7 +36,7 @@ class TestTemplate(unittest.TestCase):
         if include_optional:
             return Template(
                 created_at = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'),
-                data = '',
+                data = 'YQ==',
                 description = '',
                 forge_type = '',
                 id = 56,

--- a/charms/garm/src/garm_client/test/test_update_controller_params.py
+++ b/charms/garm/src/garm_client/test/test_update_controller_params.py
@@ -36,9 +36,7 @@ class TestUpdateControllerParams(unittest.TestCase):
         if include_optional:
             return UpdateControllerParams(
                 agent_url = '',
-                ca_cert_bundle = [
-                    56
-                    ],
+                ca_cert_bundle = 'YQ==',
                 callback_url = '',
                 clear_ca_cert_bundle = True,
                 enable_agent_tools_sync = True,

--- a/charms/garm/src/garm_client/test/test_update_gitea_endpoint_params.py
+++ b/charms/garm/src/garm_client/test/test_update_gitea_endpoint_params.py
@@ -37,9 +37,7 @@ class TestUpdateGiteaEndpointParams(unittest.TestCase):
             return UpdateGiteaEndpointParams(
                 api_base_url = '',
                 base_url = '',
-                ca_cert_bundle = [
-                    56
-                    ],
+                ca_cert_bundle = 'YQ==',
                 description = '',
                 tools_metadata_url = '',
                 use_internal_tools_metadata = True

--- a/charms/garm/src/garm_client/test/test_update_github_credentials_params.py
+++ b/charms/garm/src/garm_client/test/test_update_github_credentials_params.py
@@ -38,9 +38,7 @@ class TestUpdateGithubCredentialsParams(unittest.TestCase):
                 app = garm_client.models.github_app.GithubApp(
                     app_id = 56, 
                     installation_id = 56, 
-                    private_key_bytes = [
-                        56
-                        ], ),
+                    private_key_bytes = 'YQ==', ),
                 description = '',
                 name = '',
                 pat = garm_client.models.github_pat.GithubPAT(

--- a/charms/garm/src/garm_client/test/test_update_github_endpoint_params.py
+++ b/charms/garm/src/garm_client/test/test_update_github_endpoint_params.py
@@ -37,9 +37,7 @@ class TestUpdateGithubEndpointParams(unittest.TestCase):
             return UpdateGithubEndpointParams(
                 api_base_url = '',
                 base_url = '',
-                ca_cert_bundle = [
-                    56
-                    ],
+                ca_cert_bundle = 'YQ==',
                 description = '',
                 upload_base_url = ''
             )

--- a/charms/garm/src/garm_client/test/test_update_template_params.py
+++ b/charms/garm/src/garm_client/test/test_update_template_params.py
@@ -35,7 +35,7 @@ class TestUpdateTemplateParams(unittest.TestCase):
         model = UpdateTemplateParams()
         if include_optional:
             return UpdateTemplateParams(
-                data = '',
+                data = 'YQ==',
                 description = '',
                 name = ''
             )

--- a/charms/garm/src/github_reconciler.py
+++ b/charms/garm/src/github_reconciler.py
@@ -4,6 +4,7 @@
 
 """GitHub reconciler: diffs desired vs observed GARM GitHub credentials."""
 
+import base64
 import logging
 from dataclasses import dataclass
 
@@ -29,7 +30,7 @@ class CredentialSpec:
     endpoint: str
     app_id: int
     installation_id: int
-    private_key_bytes: str = ""
+    private_key: str = ""
     description: str = ""
 
 
@@ -102,7 +103,7 @@ class GithubReconciler:
             app=GithubApp(
                 app_id=spec.app_id,
                 installation_id=spec.installation_id,
-                private_key_bytes=spec.private_key_bytes,
+                private_key_bytes=base64.b64encode(spec.private_key.encode()).decode("utf-8"),
             ),
         )
         logger.info("Creating GitHub credential '%s'", spec.name)
@@ -125,7 +126,7 @@ class GithubReconciler:
             app=GithubApp(
                 app_id=spec.app_id,
                 installation_id=spec.installation_id,
-                private_key_bytes=spec.private_key_bytes,
+                private_key_bytes=base64.b64encode(spec.private_key.encode()).decode("utf-8"),
             ),
         )
         logger.info("Updating GitHub credential '%s' (id=%s)", spec.name, observed.id)

--- a/charms/garm/src/github_reconciler.py
+++ b/charms/garm/src/github_reconciler.py
@@ -5,7 +5,7 @@
 """GitHub reconciler: diffs desired vs observed GARM GitHub credentials."""
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from garm_api import GarmApiError, GarmAuthenticatedClient
 from garm_client.models.create_github_credentials_params import CreateGithubCredentialsParams
@@ -29,7 +29,7 @@ class CredentialSpec:
     endpoint: str
     app_id: int
     installation_id: int
-    private_key_bytes: list[int] = field(default_factory=list)
+    private_key_bytes: str = ""
     description: str = ""
 
 

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -3,7 +3,6 @@
 
 """Unit tests for GarmCharm."""
 
-import base64
 import os
 import string
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -1084,7 +1083,7 @@ def test_build_desired_credentials_builds_credential_from_relation():
     assert cred.endpoint == DEFAULT_GITHUB_ENDPOINT
     assert cred.app_id == 12345
     assert cred.installation_id == 67890
-    assert cred.private_key_bytes == base64.b64encode(b"PEMDATA").decode("utf-8")
+    assert cred.private_key == "PEMDATA"
     charm._resolve_secret_value.assert_called_once_with("secret:abc")
 
 

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -3,6 +3,7 @@
 
 """Unit tests for GarmCharm."""
 
+import base64
 import os
 import string
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -1083,7 +1084,7 @@ def test_build_desired_credentials_builds_credential_from_relation():
     assert cred.endpoint == DEFAULT_GITHUB_ENDPOINT
     assert cred.app_id == 12345
     assert cred.installation_id == 67890
-    assert cred.private_key_bytes == list(b"PEMDATA")
+    assert cred.private_key_bytes == base64.b64encode(b"PEMDATA").decode("utf-8")
     charm._resolve_secret_value.assert_called_once_with("secret:abc")
 
 

--- a/charms/garm/tests/unit/test_garm_api.py
+++ b/charms/garm/tests/unit/test_garm_api.py
@@ -10,6 +10,7 @@ import pytest
 
 from garm_api import GarmApiClient, GarmApiError, GarmAuthenticatedClient, GarmConnectionError
 from garm_client.exceptions import ApiException
+from garm_client.models.instance import Instance
 
 BASE_URL = "http://127.0.0.1:9997/api/v1"
 
@@ -541,6 +542,19 @@ def test_update_template_base64_encodes_data():
             client.update_template(template_id=3, data=data)
     body = MockApi.return_value.update_template.call_args.kwargs["body"]
     assert body.data == base64.b64encode(data).decode("utf-8")
+
+
+def test_instance_deserializes_populated_provider_fault():
+    """
+    arrange: A raw API response dict for an Instance with a populated base64 provider_fault,
+        matching GARM's wire format for a runner that failed to bootstrap on its provider.
+    act: Deserialize the dict via Instance.from_dict().
+    assert: Deserialization succeeds and provider_fault round-trips as the base64 string.
+    """
+    fault = base64.b64encode(b"boom: quota exceeded").decode("utf-8")
+    instance = Instance.from_dict({"name": "runner-1", "provider_fault": fault})
+    assert instance is not None
+    assert instance.provider_fault == fault
 
 
 @pytest.mark.parametrize(

--- a/charms/garm/tests/unit/test_github_reconciler.py
+++ b/charms/garm/tests/unit/test_github_reconciler.py
@@ -3,6 +3,7 @@
 
 """Unit tests for the GitHub reconciler."""
 
+import base64
 from unittest.mock import MagicMock
 
 from garm_api import GarmApiError
@@ -30,7 +31,7 @@ def _cred_spec(
     endpoint="github.com",
     app_id=123,
     installation_id=456,
-    private_key_bytes=None,
+    private_key=None,
     description="",
 ):
     return CredentialSpec(
@@ -38,7 +39,7 @@ def _cred_spec(
         endpoint=endpoint,
         app_id=app_id,
         installation_id=installation_id,
-        private_key_bytes=private_key_bytes or "AQID",
+        private_key=private_key or "-----PEM-----",
         description=description,
     )
 
@@ -72,7 +73,7 @@ def test_create_credential_when_missing():
     assert params.endpoint == "github.com"
     assert params.app.app_id == 123
     assert params.app.installation_id == 456
-    assert params.app.private_key_bytes == "AQID"
+    assert params.app.private_key_bytes == base64.b64encode(b"-----PEM-----").decode("utf-8")
 
 
 def test_update_adoptable_credential_when_description_changed():

--- a/charms/garm/tests/unit/test_github_reconciler.py
+++ b/charms/garm/tests/unit/test_github_reconciler.py
@@ -38,7 +38,7 @@ def _cred_spec(
         endpoint=endpoint,
         app_id=app_id,
         installation_id=installation_id,
-        private_key_bytes=private_key_bytes or [1, 2, 3],
+        private_key_bytes=private_key_bytes or "AQID",
         description=description,
     )
 
@@ -72,7 +72,7 @@ def test_create_credential_when_missing():
     assert params.endpoint == "github.com"
     assert params.app.app_id == 123
     assert params.app.installation_id == 456
-    assert params.app.private_key_bytes == [1, 2, 3]
+    assert params.app.private_key_bytes == "AQID"
 
 
 def test_update_adoptable_credential_when_description_changed():

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -86,3 +86,5 @@ scaleset
 scalesets
 OAuth
 aproxy
+[Dd]eserializ(e|es|ed|ing|ation)
+[Ss]erializ(e|es|ed|ing|ation)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ Each revision is versioned by the date of the revision.
 ## 2026-07-09
 
 - `garm`: fix runner provisioning on proxy-only networks. GARM injects a compiled-in wrapper as the cloud-init install script that must reach the GARM API before any runner-template content runs, so the aproxy bootstrap embedded in the template could never bring up egress in time and runners never registered. The aproxy setup is now delivered as a pre-install script (which GARM runs before the wrapper), apt updates are disabled on boot when a proxy is configured, and `snap set aproxy proxy=` now receives a bare `host:port` as aproxy requires.
+- `garm`: fix a charm crash when a runner fails to provision. GARM reports the IaaS provider error as a base64 string in the instance's `provider_fault`, but the generated GARM API client expected an integer array and raised a validation error, aborting every reconcile until GARM removed the faulted instance. The client is now pinned to a GARM revision that declares its byte fields as base64 strings (upstream GARM #802), so faulted instances deserialize correctly.
 
 ## 2026-07-08
 


### PR DESCRIPTION
#### What this PR does

Bumps the pinned GARM commit for the generated API client (`charms/garm/scripts/generate_client.sh`) to the merge of upstream [GARM #802](https://github.com/cloudbase/garm/pull/802), which annotates Go `[]byte` fields as `swagger:strfmt byte`. Regenerating against that spec makes `Instance.provider_fault`, the template `data` body, and `GithubApp.private_key_bytes` deserialize as base64 strings instead of `List[int]`. The now-redundant local swagger-patch step (which hand-rewrote only `data`) is removed, and `private_key_bytes` is migrated to a base64 string on the charm side.

#### Why we need it

When a runner fails to provision, GARM returns the IaaS provider error as a base64 string in the instance's `provider_fault`. The previously pinned spec declared that field as a `uint8` array, so the generated client typed it `List[int]` and raised a pydantic `ValidationError` while deserializing the scaleset's instances. This aborted the entire reconcile (config changes, scaleset updates) on every hook until GARM happened to remove the faulted instance — an intermittent, data-dependent crash that recurs whenever any reconciled instance is in a faulted state.

#### Test plan

- `tox -c tox.toml -e unit` (222 passed), `-e static` (pyright clean), `-e lint` (ruff/codespell clean).
- Added `test_instance_deserializes_populated_provider_fault` — a direct regression test asserting an `Instance` with a populated base64 `provider_fault` deserializes without raising.
- Round-trip verified that template `data` and `private_key_bytes` passed as base64 strings serialize verbatim on the wire (no double-encoding).

#### Review focus

- **`private_key_bytes` migration** — the field flips from `list[int]` to a base64 `str` (`CredentialSpec` in `github_reconciler.py`; encoded in `charm.py`). This is the one hand-written behavioural change; the credential-creation path is worth a look.
- **Version-bump surface** — regenerating pulls the whole client to a newer GARM revision. The diff is narrow (the two pinned commits are close), and no non-mechanical API mismatch surfaced against `garm_api.py`/reconcilers, but the generated churn (~48 files) is bulk.

#### Potential breaking changes / new dependencies

None user-facing. No new dependencies. The `data` wire encoding is unchanged (`garm_api.py` still base64-encodes it); the generated model type merely widened to accept it.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — N/A, no process change
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — N/A, only `AGENTS.md`/`changelog.md`/generated client docs, no user-facing documentation prose
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration — N/A
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard — N/A
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors — N/A
- [ ] **If this PR involves Rockcraft:** I updated the version — N/A
- [x] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md` (client-generation tooling changed; `charms/garm/AGENTS.md` updated)
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** re-checked AGENTS.md "12-factor divergences" — N/A, not changed
