### PR TITLE
fix(garm): replan workload layer when proxy env value changes

### DIFF
--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -477,13 +477,18 @@ class GarmCharm(paas_charm.go.Charm):
             + "\n"
             + "\n".join(f"{path}\n{content}" for path, content in sorted(provider_files.items()))
         )
-        hash_input += "\n" + "\n".join(f"{k}={v}" for k, v in sorted(proxy_env.items()))
+        # Only extend the input when a proxy is configured, so the no-proxy hash matches
+        # earlier charm revisions and upgrading doesn't force a spurious one-time replan.
+        if proxy_env:
+            hash_input += "\n" + "\n".join(f"{k}={v}" for k, v in sorted(proxy_env.items()))
         new_hash = self._hash_toml(hash_input)
 
         container = self.unit.get_container(CONTAINER_NAME)
         previous_hash = self._current_config_hash(container)
         if previous_hash == new_hash:
-            logger.debug("TOML config unchanged; skipping service restart")
+            logger.debug(
+                "Workload config (TOML, provider files, proxy env) unchanged; skipping replan"
+            )
             self._reconcile_runners()
             return
 

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -456,14 +456,6 @@ class GarmCharm(paas_charm.go.Charm):
             return
 
         proxy_env = _proxy_environment()
-        # The proxy variable *names* are rendered into the TOML (each provider's
-        # environment_variables allowlist), so toggling the proxy on or off changes the
-        # config hash below and triggers a restart. The proxy *values* live only in the
-        # Pebble service environment and are not part of that hash, so changing a value while
-        # the same variables stay set is not detected here and applies on the next config
-        # change. Detecting it properly means gating the replan on the Pebble layer
-        # environment (e.g. always replan and let Pebble diff the service env) instead of on
-        # the on-disk TOML hash; deferred to the env-driven GARM startup refactor.
         toml_content, provider_files = render_garm_toml(
             jwt_secret=secrets_data["jwt-secret"],
             db_passphrase=secrets_data["db-passphrase"],
@@ -472,15 +464,24 @@ class GarmCharm(paas_charm.go.Charm):
             proxy_var_names=sorted(proxy_env.keys()),
         )
 
-        # Detect config changes by comparing the new config hash against
-        # the hash of the config currently on disk in the container.
+        # Detect config changes by comparing the freshly rendered config hash against the
+        # config_hash stored in the container's current Pebble plan. The proxy *values* live
+        # only in the service environment, so they are folded into the hash input here; the
+        # stored hash was computed from the same input last time, making the comparison
+        # symmetric. This catches a proxy-value-only change (variable set unchanged) that the
+        # TOML-embedded variable *names* alone would miss, and — by comparing against the
+        # actual plan rather than the on-disk TOML — avoids the desync where a matching
+        # on-disk file wedged the layer permanently.
         hash_input = (
             toml_content
             + "\n"
             + "\n".join(f"{path}\n{content}" for path, content in sorted(provider_files.items()))
         )
+        hash_input += "\n" + "\n".join(f"{k}={v}" for k, v in sorted(proxy_env.items()))
         new_hash = self._hash_toml(hash_input)
-        previous_hash = self._get_on_disk_toml_hash(provider_files)
+
+        container = self.unit.get_container(CONTAINER_NAME)
+        previous_hash = self._current_config_hash(container)
         if previous_hash == new_hash:
             logger.debug("TOML config unchanged; skipping service restart")
             self._reconcile_runners()
@@ -492,7 +493,6 @@ class GarmCharm(paas_charm.go.Charm):
         provider_names = [p.get("unit_name") for p in provider_configs]
         logger.info("Updating GARM config for providers: %s", provider_names)
 
-        container = self.unit.get_container(CONTAINER_NAME)
         container.push(GARM_CONFIG_PATH, toml_content, permissions=0o600, make_dirs=True)
         for path, content in provider_files.items():
             container.push(path, content, permissions=0o600, make_dirs=True)
@@ -531,36 +531,24 @@ class GarmCharm(paas_charm.go.Charm):
         """
         return hashlib.sha256(toml_content.encode("utf-8")).hexdigest()
 
-    def _get_on_disk_toml_hash(self, provider_files: dict[str, str]) -> str | None:
-        """Compute the hash of the config currently on disk in the container.
+    @staticmethod
+    def _current_config_hash(container: ops.Container) -> str | None:
+        """Return the config_hash stored in the container's current Pebble plan.
 
-        Reads the existing config files from the container, constructs the
-        same hash input used during render, and returns its SHA-256 digest.
-        Returns None if the config file does not yet exist on disk.
+        This is the config hash computed during the previous successful replan;
+        it lives in the app service's environment. Returns None when the service
+        (or the key) is absent, i.e. the container was never configured.
 
         Args:
-            provider_files: The new provider files dict (used only for keys).
+            container: The workload container to read the plan from.
 
         Returns:
-            The SHA-256 hex digest of the on-disk config, or None if
-            the main config file does not exist yet.
+            The stored config_hash, or None if it has not been set yet.
         """
-        container = self.unit.get_container(CONTAINER_NAME)
-        try:
-            existing_toml = container.pull(GARM_CONFIG_PATH).read()
-        except (ops.pebble.PathError, FileNotFoundError):
+        service = container.get_plan().services.get(PEBBLE_SERVICE_NAME)
+        if service is None:
             return None
-
-        existing_provider_parts: list[str] = []
-        for path in sorted(provider_files.keys()):
-            try:
-                existing_provider_parts.append(f"{path}\n{container.pull(path).read()}")
-            except (ops.pebble.PathError, FileNotFoundError):
-                # If a provider file is missing, the config has changed.
-                return None
-
-        hash_input = existing_toml + "\n" + "\n".join(existing_provider_parts)
-        return self._hash_toml(hash_input)
+        return service.environment.get("config_hash")
 
     def _ensure_secrets(self) -> None:
         """Create garm-secrets and garm-admin-credentials (leader only)."""

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -853,10 +853,12 @@ def test_restart_proxy_value_change_forces_layer_rewrite():
     charm = _make_restart_charm(previous_plan_env={"config_hash": old_hash, **old_proxy})
     charm._maybe_first_run.side_effect = StopIteration(_SENTINEL)
 
-    with patch.dict(os.environ, new_env, clear=True):
-        with patch("charm.GarmApiClient"):
-            with pytest.raises(StopIteration):
-                GarmCharm.restart(charm)
+    with (
+        patch.dict(os.environ, new_env, clear=True),
+        patch("charm.GarmApiClient"),
+        pytest.raises(StopIteration),
+    ):
+        GarmCharm.restart(charm)
 
     charm.unit.get_container.return_value.add_layer.assert_called_once()
     service_env = _layer_service_env(charm)
@@ -880,10 +882,12 @@ def test_restart_clearing_proxy_removes_it_from_layer():
     charm = _make_restart_charm(previous_plan_env={"config_hash": old_hash, **old_proxy})
     charm._maybe_first_run.side_effect = StopIteration(_SENTINEL)
 
-    with patch.dict(os.environ, {}, clear=True):
-        with patch("charm.GarmApiClient"):
-            with pytest.raises(StopIteration):
-                GarmCharm.restart(charm)
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("charm.GarmApiClient"),
+        pytest.raises(StopIteration),
+    ):
+        GarmCharm.restart(charm)
 
     charm.unit.get_container.return_value.add_layer.assert_called_once()
     service_env = _layer_service_env(charm)
@@ -906,9 +910,11 @@ def test_restart_unchanged_config_skips_replan():
 
     charm = _make_restart_charm(previous_plan_env={"config_hash": current_hash, **current_proxy})
 
-    with patch.dict(os.environ, proxy_env, clear=True):
-        with patch("charm.GarmApiClient"):
-            GarmCharm.restart(charm)
+    with (
+        patch.dict(os.environ, proxy_env, clear=True),
+        patch("charm.GarmApiClient"),
+    ):
+        GarmCharm.restart(charm)
 
     charm.unit.get_container.return_value.add_layer.assert_not_called()
     charm.unit.get_container.return_value.replan.assert_not_called()

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -678,12 +678,68 @@ def test_render_garm_toml_no_proxy_var_names_omits_key():
         assert "environment_variables" not in provider["external"]
 
 
-def _make_restart_charm() -> MagicMock:
+_RESTART_PROVIDER_CONFIGS = [
+    {
+        "unit_name": "garm-configurator-0",
+        "auth_url": "https://ks1.example.com:5000/v3",
+        "username": "admin1",
+        "password": "pass1",
+        "project_name": "proj1",
+        "user_domain_name": "Default",
+        "project_domain_name": "Default",
+        "region_name": "RegionOne",
+        "network": "net1",
+    }
+]
+
+
+def _plan_with_service_env(environment: dict | None) -> ops.pebble.Plan:
+    """Build a Pebble plan whose 'app' service carries the given environment.
+
+    Passing None yields an empty plan (no 'app' service), which models a
+    container that has never been configured — previous_hash resolves to None.
+    """
+    if environment is None:
+        return ops.pebble.Plan()
+    plan = ops.pebble.Plan()
+    plan.services["app"] = ops.pebble.Service(
+        "app",
+        {"override": "replace", "command": "x", "environment": environment},
+    )
+    return plan
+
+
+def _expected_config_hash(proxy_env: dict, providers: list | None = None) -> str:
+    """Reproduce restart()'s hash-input construction for assertion purposes.
+
+    Mirrors the exact serialization restart() feeds into _hash_toml: the
+    rendered TOML, the sorted provider files, then the sorted proxy env
+    key=value pairs.
+    """
+    providers = _RESTART_PROVIDER_CONFIGS if providers is None else providers
+    toml_content, provider_files = render_garm_toml(
+        jwt_secret="test-jwt-secret",
+        db_passphrase="a" * 32,
+        postgresql_config=_DEFAULT_PG_CONFIG,
+        providers=providers,
+        proxy_var_names=sorted(proxy_env.keys()),
+    )
+    hash_input = (
+        toml_content
+        + "\n"
+        + "\n".join(f"{path}\n{content}" for path, content in sorted(provider_files.items()))
+    )
+    hash_input += "\n" + "\n".join(f"{k}={v}" for k, v in sorted(proxy_env.items()))
+    return GarmCharm._hash_toml(hash_input)
+
+
+def _make_restart_charm(previous_plan_env: dict | None = None) -> MagicMock:
     """Build a minimal GarmCharm mock suitable for testing restart() proxy injection.
 
     Mirrors the mock setup pattern used by existing restart-related tests.
-    The mock overrides _hash_toml and _get_on_disk_toml_hash so the actual
-    hash logic runs without needing a real Pebble container.
+    The mock wires the real _hash_toml so the actual hash logic runs, and
+    seeds the container's current Pebble plan (the source of previous_hash)
+    from ``previous_plan_env``; None models a never-configured container.
     """
     charm = MagicMock()
     charm.is_ready.return_value = True
@@ -699,29 +755,19 @@ def _make_restart_charm() -> MagicMock:
     }
 
     # Configurator provider configs — one real provider so render succeeds.
-    charm._get_configurator_provider_configs.return_value = [
-        {
-            "unit_name": "garm-configurator-0",
-            "auth_url": "https://ks1.example.com:5000/v3",
-            "username": "admin1",
-            "password": "pass1",
-            "project_name": "proj1",
-            "user_domain_name": "Default",
-            "project_domain_name": "Default",
-            "region_name": "RegionOne",
-            "network": "net1",
-        }
-    ]
+    charm._get_configurator_provider_configs.return_value = list(_RESTART_PROVIDER_CONFIGS)
 
     # Wire the real hash function so hash assertions are meaningful.
     # _hash_toml is a staticmethod, so GarmCharm._hash_toml is already a plain
     # function — pass it directly as the side_effect.
     charm._hash_toml.side_effect = GarmCharm._hash_toml
 
-    # No existing config on disk → the on-disk hash never matches, forcing the
-    # replan path (the proxy comparison is short-circuited and irrelevant here).
-    charm._get_on_disk_toml_hash.return_value = None
+    # _current_config_hash is a staticmethod; run the real plan-reading logic
+    # against the seeded container plan (the source of previous_hash).
+    charm._current_config_hash.side_effect = GarmCharm._current_config_hash
+
     mock_container = MagicMock()
+    mock_container.get_plan.return_value = _plan_with_service_env(previous_plan_env)
     charm.unit.get_container.return_value = mock_container
 
     return charm
@@ -769,12 +815,12 @@ def test_restart_proxy_vars_appear_in_pebble_layer():
     assert "config_hash" in service_env
 
 
-def test_restart_no_proxy_hash_matches_on_disk_format():
+def test_restart_no_proxy_hash_matches_rendered_config():
     """
     arrange: No proxy vars are set; the charm renders config for one provider.
     act: Run restart() and capture the config_hash it computes.
-    assert: It equals the hash of the rendered config in _get_on_disk_toml_hash's
-            format, so an unchanged config never triggers a spurious replan.
+    assert: It equals the hash of the rendered config folded with the (empty)
+            proxy env, so an unchanged config never triggers a spurious replan.
     """
     charm = _make_restart_charm()
     charm._maybe_first_run.side_effect = StopIteration(_SENTINEL)
@@ -785,18 +831,87 @@ def test_restart_no_proxy_hash_matches_on_disk_format():
                 GarmCharm.restart(charm)
     captured = _layer_service_env(charm)["config_hash"]
 
-    toml_content, provider_files = render_garm_toml(
-        jwt_secret="test-jwt-secret",
-        db_passphrase="a" * 32,
-        postgresql_config=_DEFAULT_PG_CONFIG,
-        providers=charm._get_configurator_provider_configs.return_value,
-    )
-    expected_input = (
-        toml_content
-        + "\n"
-        + "\n".join(f"{path}\n{content}" for path, content in sorted(provider_files.items()))
-    )
-    assert captured == GarmCharm._hash_toml(expected_input)
+    assert captured == _expected_config_hash({})
+
+
+def test_restart_proxy_value_change_forces_layer_rewrite():
+    """
+    arrange: The container's current plan already carries a config_hash and an
+             http_proxy value computed from proxy value A; the model proxy is
+             now value B (same variable set, only the value changed).
+    act: Run restart().
+    assert: The rewritten layer's service environment reflects value B, i.e. a
+            proxy-value-only change is detected and replanned.
+    """
+    old_env = {"JUJU_CHARM_HTTP_PROXY": "http://proxy-a.example.com:3128"}
+    new_env = {"JUJU_CHARM_HTTP_PROXY": "http://proxy-b.example.com:3128"}
+    with patch.dict(os.environ, old_env, clear=True):
+        old_proxy = _proxy_environment()
+    old_hash = _expected_config_hash(old_proxy)
+
+    charm = _make_restart_charm(previous_plan_env={"config_hash": old_hash, **old_proxy})
+    charm._maybe_first_run.side_effect = StopIteration(_SENTINEL)
+
+    with patch.dict(os.environ, new_env, clear=True):
+        with patch("charm.GarmApiClient"):
+            with pytest.raises(StopIteration):
+                GarmCharm.restart(charm)
+
+    charm.unit.get_container.return_value.add_layer.assert_called_once()
+    service_env = _layer_service_env(charm)
+    assert service_env["http_proxy"] == "http://proxy-b.example.com:3128"
+    assert service_env["HTTP_PROXY"] == "http://proxy-b.example.com:3128"
+
+
+def test_restart_clearing_proxy_removes_it_from_layer():
+    """
+    arrange: The container's current plan carries a proxy value; the model proxy
+             is now cleared (empty).
+    act: Run restart().
+    assert: The rewritten layer's service environment no longer contains the
+            proxy keys.
+    """
+    old_env = {"JUJU_CHARM_HTTP_PROXY": "http://proxy-a.example.com:3128"}
+    with patch.dict(os.environ, old_env, clear=True):
+        old_proxy = _proxy_environment()
+    old_hash = _expected_config_hash(old_proxy)
+
+    charm = _make_restart_charm(previous_plan_env={"config_hash": old_hash, **old_proxy})
+    charm._maybe_first_run.side_effect = StopIteration(_SENTINEL)
+
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("charm.GarmApiClient"):
+            with pytest.raises(StopIteration):
+                GarmCharm.restart(charm)
+
+    charm.unit.get_container.return_value.add_layer.assert_called_once()
+    service_env = _layer_service_env(charm)
+    assert "http_proxy" not in service_env
+    assert "HTTP_PROXY" not in service_env
+
+
+def test_restart_unchanged_config_skips_replan():
+    """
+    arrange: The container's current plan already stores the config_hash that
+             the current state (same proxy, same config) renders to.
+    act: Run restart().
+    assert: The early-return path is taken — no new layer is added and the
+            service is not replanned — while runners are still reconciled.
+    """
+    proxy_env = {"JUJU_CHARM_HTTP_PROXY": "http://proxy.example.com:3128"}
+    with patch.dict(os.environ, proxy_env, clear=True):
+        current_proxy = _proxy_environment()
+    current_hash = _expected_config_hash(current_proxy)
+
+    charm = _make_restart_charm(previous_plan_env={"config_hash": current_hash, **current_proxy})
+
+    with patch.dict(os.environ, proxy_env, clear=True):
+        with patch("charm.GarmApiClient"):
+            GarmCharm.restart(charm)
+
+    charm.unit.get_container.return_value.add_layer.assert_not_called()
+    charm.unit.get_container.return_value.replan.assert_not_called()
+    charm._reconcile_runners.assert_called_once()
 
 
 def test_render_garm_toml_default_provider_applies_proxy_var_names():

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -713,8 +713,8 @@ def _expected_config_hash(proxy_env: dict, providers: list | None = None) -> str
     """Reproduce restart()'s hash-input construction for assertion purposes.
 
     Mirrors the exact serialization restart() feeds into _hash_toml: the
-    rendered TOML, the sorted provider files, then the sorted proxy env
-    key=value pairs.
+    rendered TOML, the sorted provider files, then — only when a proxy is
+    configured — the sorted proxy env key=value pairs.
     """
     providers = _RESTART_PROVIDER_CONFIGS if providers is None else providers
     toml_content, provider_files = render_garm_toml(
@@ -729,7 +729,8 @@ def _expected_config_hash(proxy_env: dict, providers: list | None = None) -> str
         + "\n"
         + "\n".join(f"{path}\n{content}" for path, content in sorted(provider_files.items()))
     )
-    hash_input += "\n" + "\n".join(f"{k}={v}" for k, v in sorted(proxy_env.items()))
+    if proxy_env:
+        hash_input += "\n" + "\n".join(f"{k}={v}" for k, v in sorted(proxy_env.items()))
     return GarmCharm._hash_toml(hash_input)
 
 

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -88,3 +88,4 @@ OAuth
 aproxy
 [Dd]eserializ(e|es|ed|ing|ation)
 [Ss]erializ(e|es|ed|ing|ation)
+[Rr]eplan(s|ned|ning)?

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-10
+
+- `garm`: reliably apply proxy changes to the GARM workload. The charm gated the workload's Pebble layer rewrite on a hash of the on-disk config file, which excluded the proxy environment *values* — so changing or clearing a proxy value while the variable set stayed the same never rewrote the layer, leaving the old value in the plan. The on-disk file could also drift from the layer and wedge it permanently. The charm now compares the freshly rendered hash (which includes the proxy values) against the `config_hash` stored in the container's current Pebble plan, so proxy value changes and clears reliably replan the workload.
+
 ## 2026-07-09
 
 - `garm`: apply the Docker registry mirror and runner host preparation on the runner. GARM runs the injected runner-install steps as the unprivileged `runner` user, but the Docker-mirror and host-prep steps ran without `sudo`, so writing `/etc/docker/daemon.json`, restarting Docker, and adding the runner to the `lxd`/`adm` groups all failed silently — the mirror and group membership were never applied. These steps now escalate with `sudo`, matching the rest of the install script.


### PR DESCRIPTION
#### What this PR does

Fixes proxy config changes not reaching the GARM workload. `restart()` gated the Pebble layer rewrite on a hash of the on-disk `config.toml`, which only captured the proxy variable *names* (via the provider `environment_variables` allowlist) — never the *values*. So changing or clearing a proxy value while the variable set stayed the same left the stale value in the plan, and the on-disk file could drift from the layer and wedge it permanently.

The gate now folds the proxy env values into the rendered hash and compares it against the `config_hash` stored in the container's **current Pebble plan** (rather than re-hashing the on-disk file). The comparison is symmetric (the stored hash was computed from the same input), so a proxy value change or clear reliably replans the workload, and the plan-vs-file desync can no longer strand the layer.

#### Why we need it

Setting `juju-http-proxy=""` (or changing a proxy value) did not update the workload's Pebble plan — the old value persisted, and no config-change could flush it. This makes proxy reconfiguration behave predictably.

#### Test plan

- New unit tests in `charms/garm/tests/unit/test_charm.py`: a proxy value change forces a layer rewrite, clearing the proxy removes the keys from the service env, and an unchanged reconcile still skips the replan (this last case reproduced the desync bug before the fix).
- `tox -c tox.toml`: `unit` (225 passed), `static`, `lint`, `fmt`, `complexity`, `coverage-report` all green.

#### Review focus

- The hash source moved from `_get_on_disk_toml_hash()` (removed) to `_current_config_hash(container)`, which reads `config_hash` from the current plan's `app` service env, returning `None` when unset. Worth confirming this is the right source of truth vs. the on-disk file.
- A genuine proxy value change now restarts the `app` service (unavoidable — Pebble must restart to change service env). Unchanged reconciles still take the early return, preserving the "sync scalesets without restart" behavior.

#### Breaking changes / dependencies

None. No new dependencies, APIs, or workflow changes.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run)
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR involves Rockcraft:** I updated the version
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md`
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked the `AGENTS.md` "12-factor divergences" guidance

Non-applicable checklist items (no contribution-process change, no doc content beyond changelog, no integration modules, dashboard, Terraform, Rockcraft, charm-structure, or copilot-collections changes) are left unchecked.
