### PR TITLE
fix(garm): write runner options to the .env file the runner reads

### DIFF
--- a/charms/garm/src/runner_template.py
+++ b/charms/garm/src/runner_template.py
@@ -44,10 +44,12 @@ import jinja2
 
 from charm_state import RunnerConfig
 
-# The runner account is uid 1000, home /home/ubuntu, so its actions-runner
-# install lives under /home/ubuntu rather than /home/runner; the GitHub Actions
-# runner service reads a `.env` file (a dotfile) from that directory (matching
-# github-runner-manager's production openstack-userdata.sh.j2).
+# /home/runner symlinks to /home/ubuntu (both are uid 1000's home), so the
+# directory was never the issue -- the actual bug is the filename: the GitHub
+# Actions runner sources a `.env` dotfile, not a plain `env`, which is why the
+# injected options were silently dropped. Target /home/ubuntu directly rather
+# than lean on the symlink (matching github-runner-manager's production
+# openstack-userdata.sh.j2).
 RUNNER_USER = "runner"
 RUNNER_HOME = "/home/ubuntu/actions-runner"
 PRE_JOB_HOOK_PATH = f"{RUNNER_HOME}/pre-job.sh"

--- a/charms/garm/src/runner_template.py
+++ b/charms/garm/src/runner_template.py
@@ -14,8 +14,8 @@ abort the whole bootstrap:
     unprivileged ``runner`` user, escalating each privileged step with ``sudo``
     (docker registry mirror, static host prep), and
   * a *runner job hooks* block that writes the GitHub job-start hook and the
-    runner ``.env`` file under ``/home/ubuntu/actions-runner``, the runner's
-    actual install directory.
+    runner ``.env`` file under ``/home/runner/actions-runner`` (the runner's
+    home; a symlink to ``/home/ubuntu`` on the GARM image).
 
 The proxy/aproxy option is *not* injected into this template: GARM prepends a
 compiled-in wrapper script that curls this template from the GARM metadata API
@@ -44,14 +44,12 @@ import jinja2
 
 from charm_state import RunnerConfig
 
-# /home/runner symlinks to /home/ubuntu (both are uid 1000's home), so the
-# directory was never the issue -- the actual bug is the filename: the GitHub
-# Actions runner sources a `.env` dotfile, not a plain `env`, which is why the
-# injected options were silently dropped. Target /home/ubuntu directly rather
-# than lean on the symlink (matching github-runner-manager's production
-# openstack-userdata.sh.j2).
+# The bug this path fixes is the filename: the GitHub Actions runner sources a
+# `.env` dotfile, not a plain `env`, so the injected options were silently
+# dropped. /home/runner is the runner's home (a symlink to /home/ubuntu on the
+# GARM image), kept consistent with garm_template.py.
 RUNNER_USER = "runner"
-RUNNER_HOME = "/home/ubuntu/actions-runner"
+RUNNER_HOME = "/home/runner/actions-runner"
 PRE_JOB_HOOK_PATH = f"{RUNNER_HOME}/pre-job.sh"
 RUNNER_ENV_PATH = f"{RUNNER_HOME}/.env"
 

--- a/charms/garm/src/runner_template.py
+++ b/charms/garm/src/runner_template.py
@@ -14,8 +14,8 @@ abort the whole bootstrap:
     unprivileged ``runner`` user, escalating each privileged step with ``sudo``
     (docker registry mirror, static host prep), and
   * a *runner job hooks* block that writes the GitHub job-start hook and the
-    runner ``env`` file under ``/home/runner/actions-runner`` (GARM hardcodes the
-    ``runner`` user and that path).
+    runner ``.env`` file under ``/home/ubuntu/actions-runner``, the runner's
+    actual install directory.
 
 The proxy/aproxy option is *not* injected into this template: GARM prepends a
 compiled-in wrapper script that curls this template from the GARM metadata API
@@ -44,12 +44,14 @@ import jinja2
 
 from charm_state import RunnerConfig
 
-# GARM hardcodes the runner username and actions-runner directory; the env file
-# read by the runner service therefore lives at the path below.
+# The runner account is uid 1000, home /home/ubuntu, so its actions-runner
+# install lives under /home/ubuntu rather than /home/runner; the GitHub Actions
+# runner service reads a `.env` file (a dotfile) from that directory (matching
+# github-runner-manager's production openstack-userdata.sh.j2).
 RUNNER_USER = "runner"
-RUNNER_HOME = "/home/runner/actions-runner"
+RUNNER_HOME = "/home/ubuntu/actions-runner"
 PRE_JOB_HOOK_PATH = f"{RUNNER_HOME}/pre-job.sh"
-RUNNER_ENV_PATH = f"{RUNNER_HOME}/env"
+RUNNER_ENV_PATH = f"{RUNNER_HOME}/.env"
 
 _TEMPLATES_DIR = pathlib.Path(__file__).parent / "templates"
 _JINJA_ENV = jinja2.Environment(

--- a/charms/garm/src/runner_template.py
+++ b/charms/garm/src/runner_template.py
@@ -14,8 +14,7 @@ abort the whole bootstrap:
     unprivileged ``runner`` user, escalating each privileged step with ``sudo``
     (docker registry mirror, static host prep), and
   * a *runner job hooks* block that writes the GitHub job-start hook and the
-    runner ``.env`` file under ``/home/runner/actions-runner`` (the runner's
-    home; a symlink to ``/home/ubuntu`` on the GARM image).
+    runner ``.env`` file under ``/home/runner/actions-runner``.
 
 The proxy/aproxy option is *not* injected into this template: GARM prepends a
 compiled-in wrapper script that curls this template from the GARM metadata API
@@ -44,10 +43,8 @@ import jinja2
 
 from charm_state import RunnerConfig
 
-# The bug this path fixes is the filename: the GitHub Actions runner sources a
-# `.env` dotfile, not a plain `env`, so the injected options were silently
-# dropped. /home/runner is the runner's home (a symlink to /home/ubuntu on the
-# GARM image), kept consistent with garm_template.py.
+# GARM installs the runner under the `runner` user's home; the GitHub Actions
+# runner sources a `.env` dotfile from that directory.
 RUNNER_USER = "runner"
 RUNNER_HOME = "/home/runner/actions-runner"
 PRE_JOB_HOOK_PATH = f"{RUNNER_HOME}/pre-job.sh"

--- a/charms/garm/tests/unit/test_runner_template.py
+++ b/charms/garm/tests/unit/test_runner_template.py
@@ -66,6 +66,25 @@ def test_build_template_data_injects_all_options():
     assert "rm /tmp/custom_pre_job_script" in result
 
 
+def test_build_template_data_writes_env_and_hook_under_home_ubuntu():
+    """
+    arrange: A bootstrap script and a runner config with every optional field set.
+    act: Build the runner template data.
+    assert: The env vars are written to a dot-env under /home/ubuntu/actions-runner and
+        the pre-job hook is written alongside it — the directory and file the GitHub
+        Actions runner (running as uid 1000, home /home/ubuntu) actually reads, matching
+        github-runner-manager's openstack-userdata.sh.j2.
+    """
+    result = build_template_data(SAMPLE_BASE, _full_config()).decode()
+
+    assert "cat >> /home/ubuntu/actions-runner/.env <<" in result
+    assert "cat > /home/ubuntu/actions-runner/pre-job.sh <<" in result
+
+    # The old, dotless env path must never appear as a write target.
+    assert "cat >> /home/ubuntu/actions-runner/env <<" not in result
+    assert "/home/runner/actions-runner" not in result
+
+
 def test_build_template_data_empty_config_omits_optional_blocks():
     """
     arrange: A bootstrap script and an empty runner config.

--- a/charms/garm/tests/unit/test_runner_template.py
+++ b/charms/garm/tests/unit/test_runner_template.py
@@ -66,23 +66,21 @@ def test_build_template_data_injects_all_options():
     assert "rm /tmp/custom_pre_job_script" in result
 
 
-def test_build_template_data_writes_env_and_hook_under_home_ubuntu():
+def test_build_template_data_writes_env_to_dotfile():
     """
     arrange: A bootstrap script and a runner config with every optional field set.
     act: Build the runner template data.
-    assert: The env vars are written to a dot-env under /home/ubuntu/actions-runner and
-        the pre-job hook is written alongside it — the directory and file the GitHub
-        Actions runner (running as uid 1000, home /home/ubuntu) actually reads, matching
-        github-runner-manager's openstack-userdata.sh.j2.
+    assert: The env vars are written to a `.env` dotfile — the file the GitHub Actions
+        runner sources — not a plain `env`, with the hook written alongside it under the
+        runner's home (/home/runner, a symlink to /home/ubuntu on the image).
     """
     result = build_template_data(SAMPLE_BASE, _full_config()).decode()
 
-    assert "cat >> /home/ubuntu/actions-runner/.env <<" in result
-    assert "cat > /home/ubuntu/actions-runner/pre-job.sh <<" in result
+    assert "cat >> /home/runner/actions-runner/.env <<" in result
+    assert "cat > /home/runner/actions-runner/pre-job.sh <<" in result
 
-    # The old, dotless env path must never appear as a write target.
-    assert "cat >> /home/ubuntu/actions-runner/env <<" not in result
-    assert "/home/runner/actions-runner" not in result
+    # The dotless env file the runner never sources must not be a write target.
+    assert "cat >> /home/runner/actions-runner/env <<" not in result
 
 
 def test_build_template_data_empty_config_omits_optional_blocks():

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-07-12
 
-- `garm`: fix the injected runner-option environment variables so the runner actually reads them. They were written to a file named `env`, but the GitHub Actions runner sources a `.env` file, so the Docker mirror, OpenTelemetry endpoint, job-started hook, and pre-job-script options were silently ignored. They are now written to the `.env` file the runner reads, under the runner's actual install directory `/home/ubuntu/actions-runner`.
+- `garm`: fix the injected runner-option environment variables so the runner actually reads them. They were written to a file named `env`, but the GitHub Actions runner sources a `.env` file, so the Docker mirror, OpenTelemetry endpoint, job-started hook, and pre-job-script options were silently ignored. They are now written to the `.env` file the runner reads.
 
 ## 2026-07-09
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-12
+
+- `garm`: fix the injected runner-option environment variables and pre-job hook so the runner actually reads them. They were written under `/home/runner/actions-runner`, with the variables in a file named `env` rather than `.env`, but the runner runs from `/home/ubuntu/actions-runner` and reads its variables from `.env`, so the Docker mirror, OpenTelemetry endpoint, job-started hook, and pre-job-script options were silently ignored. They are now written to `/home/ubuntu/actions-runner/.env` and `/home/ubuntu/actions-runner/pre-job.sh`, matching the runner's actual install directory.
+
 ## 2026-07-09
 
 - `garm`: apply the Docker registry mirror and runner host preparation on the runner. GARM runs the injected runner-install steps as the unprivileged `runner` user, but the Docker-mirror and host-prep steps ran without `sudo`, so writing `/etc/docker/daemon.json`, restarting Docker, and adding the runner to the `lxd`/`adm` groups all failed silently — the mirror and group membership were never applied. These steps now escalate with `sudo`, matching the rest of the install script.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-07-12
 
-- `garm`: fix the injected runner-option environment variables and pre-job hook so the runner actually reads them. They were written under `/home/runner/actions-runner`, with the variables in a file named `env` rather than `.env`, but the runner runs from `/home/ubuntu/actions-runner` and reads its variables from `.env`, so the Docker mirror, OpenTelemetry endpoint, job-started hook, and pre-job-script options were silently ignored. They are now written to `/home/ubuntu/actions-runner/.env` and `/home/ubuntu/actions-runner/pre-job.sh`, matching the runner's actual install directory.
+- `garm`: fix the injected runner-option environment variables so the runner actually reads them. They were written to a file named `env`, but the GitHub Actions runner sources a `.env` file, so the Docker mirror, OpenTelemetry endpoint, job-started hook, and pre-job-script options were silently ignored. They are now written to the `.env` file the runner reads, under the runner's actual install directory `/home/ubuntu/actions-runner`.
 
 ## 2026-07-09
 


### PR DESCRIPTION
#### What this PR does

Fixes the injected runner-option delivery so the runner actually reads it. The env vars (Docker mirror, OpenTelemetry endpoint, job-started hook) were written to a file named `env`, but the GitHub Actions runner sources a `.env` file — so it never read them and the Docker-mirror, OTel, and pre-job-script options were silently ignored (jobs ran green regardless). They are now written to `.env`. One-line root cause: the filename.

#### Why we need it

Without this, none of the runner-behaviour options delivered via the runner `.env` take effect. On a restricted network the missing Docker mirror / proxy means jobs fail to pull images; telemetry is never exported; the operator's `pre-job-script` never runs. Nothing surfaces the failure because the workflow still succeeds.

#### Test plan

- New unit regression test (`test_build_template_data_writes_env_to_dotfile`) pins the write target to a `.env` dotfile and guards against the dotless `env`. Added failing-first, then fixed.
- `tox -c tox.toml -e unit` (223 passed), `lint`, `static` all pass; `make -C docs spellcheck` clean.
- **On-runner diagnosis (pre-fix `main` build):** confirmed the runner root is `/home/ubuntu/actions-runner`, that `.env` held only `LANG=C.UTF-8`, and that all four option vars sat in a sibling `env` file the runner never sources — reproducing the silent drop.
- **Verified in production via livepatch:** patched `RUNNER_ENV_PATH` on the running charm, triggered a reconcile (template updated in GARM), and ran a fresh runner. The runner now executes the job-started hook, the OTel collector setup, and the custom pre-job script, and the job sees `ACTIONS_RUNNER_HOOK_JOB_STARTED`, `DOCKERHUB_MIRROR`, `CONTAINER_REGISTRY_URL`, and `ACTION_OTEL_EXPORTER_OTLP_ENDPOINT` all populated. Confirms our appended `.env` block coexists with the runner's own `env.sh` (no clobber / ordering issue).

#### Review focus

- **Filename is the fix.** The `env` → `.env` rename is the whole change — the GitHub Actions runner sources a `.env` dotfile. The path stays `/home/runner/actions-runner`, the standard GitHub `runner` user's home, consistent with `garm_template.py`.
- **Ordering.** Our block appends to `.env` early (before the runner is configured); the runner's own `env.sh` later appends `LANG` (append-only, no truncate), so both survive. This is the one thing worth confirming on a branch build (see Test plan).
- **Behaviour change, not API change:** options previously ignored now take effect on runners.

#### Related (out of scope — for the debug-ssh/tmate owner)

`garm_template.py`'s `build_tmate_env_snippet` writes the `TMATE_SERVER_*` vars to `/home/runner/.env` (the home-directory root), but the runner sources its env from `/home/runner/actions-runner/.env` — so, like the bug fixed here, those vars are never picked up and ssh-debug/tmate wouldn't receive its server config. Left for the engineer working on tmate to avoid scope creep. Likely a one-line change (point it at `/home/runner/actions-runner/.env`); not runtime-verified.

#### Potential breaking changes

None to config or interfaces. Runtime behaviour changes only in that correctly-configured runner options now apply.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — N/A, no process change
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — only a routine `changelog.md` entry, no prose docs
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration — N/A
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard — N/A
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors — N/A
- [ ] **If this PR involves Rockcraft:** I updated the version — N/A, no rockcraft change
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md` — N/A, no convention change
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** re-checked AGENTS.md 12-factor divergences — N/A
