### PR TITLE
fix(garm): reconcile scalesets when garm-configurator relation is removed

### DIFF
--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -25,6 +25,7 @@ from charm_state import (
     GARM_CONFIGURATOR_RELATION_NAME,
     CharmState,
     RunnerConfig,
+    configurator_related,
     credential_name,
 )
 from entity_reconciler import EntityReconciler
@@ -450,17 +451,12 @@ class GarmCharm(paas_charm.go.Charm):
 
         provider_configs = self._get_configurator_provider_configs()
         if not provider_configs:
-            # Empty provider configs are ambiguous: the garm-configurator relation
-            # may be gone, or still present but not yet publishing its
-            # secret-dependent fields (auth_url and image_id appear together once
-            # the image UUID and secrets are available). Only a removed relation
-            # leaves its scalesets orphaned and eligible for pruning; reconciling
-            # while the relation is merely mid-publish would delete live scalesets
-            # against a still-empty desired state. _reconcile_runners() is the only
-            # caller of ScalesetReconciler's orphan-delete, so run it here when —
-            # and only when — the relation is absent. GARM otherwise keeps the
-            # orphaned scalesets registered indefinitely.
-            if self.model.get_relation(GARM_CONFIGURATOR_RELATION_NAME) is None:
+            # Empty configs don't distinguish a removed relation from one still
+            # mid-publish, but only a removed relation orphans scalesets. Prune
+            # them (via _reconcile_runners) only when the relation is truly gone;
+            # reconciling mid-publish would delete live scalesets against an empty
+            # desired state.
+            if not configurator_related(self):
                 self._reconcile_runners()
             self.update_app_and_unit_status(
                 ops.WaitingStatus("Waiting for garm-configurator relation")

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -25,7 +25,6 @@ from charm_state import (
     GARM_CONFIGURATOR_RELATION_NAME,
     CharmState,
     RunnerConfig,
-    configurator_related,
     credential_name,
 )
 from entity_reconciler import EntityReconciler
@@ -435,7 +434,7 @@ class GarmCharm(paas_charm.go.Charm):
             # them (via _reconcile_runners) only when the relation is truly gone;
             # reconciling mid-publish would delete live scalesets against an empty
             # desired state.
-            if not configurator_related(self):
+            if not CharmState.from_charm(self).configurator_related:
                 self._reconcile_runners()
             self.update_app_and_unit_status(
                 ops.WaitingStatus("Waiting for garm-configurator relation")

--- a/charms/garm/src/charm.py
+++ b/charms/garm/src/charm.py
@@ -450,6 +450,18 @@ class GarmCharm(paas_charm.go.Charm):
 
         provider_configs = self._get_configurator_provider_configs()
         if not provider_configs:
+            # Empty provider configs are ambiguous: the garm-configurator relation
+            # may be gone, or still present but not yet publishing its
+            # secret-dependent fields (auth_url and image_id appear together once
+            # the image UUID and secrets are available). Only a removed relation
+            # leaves its scalesets orphaned and eligible for pruning; reconciling
+            # while the relation is merely mid-publish would delete live scalesets
+            # against a still-empty desired state. _reconcile_runners() is the only
+            # caller of ScalesetReconciler's orphan-delete, so run it here when —
+            # and only when — the relation is absent. GARM otherwise keeps the
+            # orphaned scalesets registered indefinitely.
+            if self.model.get_relation(GARM_CONFIGURATOR_RELATION_NAME) is None:
+                self._reconcile_runners()
             self.update_app_and_unit_status(
                 ops.WaitingStatus("Waiting for garm-configurator relation")
             )

--- a/charms/garm/src/charm_state.py
+++ b/charms/garm/src/charm_state.py
@@ -319,10 +319,7 @@ class CharmState:
     Attributes:
         ssh_debug_connections: SSH debug connection info from the debug-ssh relation.
         desired_entities: GARM org/repo entities derived from the garm-configurator relation.
-        configurator_related: Whether a garm-configurator relation is present. Empty desired state
-            alone can't distinguish a removed relation from one still mid-publish; only a removed
-            relation orphans the scalesets it configured, so callers prune orphaned scalesets only
-            when this is False.
+        configurator_related: Whether a garm-configurator relation is present.
     """
 
     ssh_debug_connections: list[SSHDebugInfo]

--- a/charms/garm/src/charm_state.py
+++ b/charms/garm/src/charm_state.py
@@ -173,23 +173,6 @@ def credential_name(app_id: int, installation_id: int) -> str:
     return f"app-{app_id}-{installation_id}"
 
 
-def configurator_related(charm: ops.CharmBase) -> bool:
-    """Whether a garm-configurator relation is present.
-
-    An absent relation and one that is present but not yet publishing its provider fields both
-    yield empty desired state, so callers can't tell them apart from the desired state alone.
-    Only a removed relation orphans the scalesets it configured, so only the absent case should
-    trigger their pruning.
-
-    Args:
-        charm: The charm instance.
-
-    Returns:
-        True if the garm-configurator relation exists.
-    """
-    return charm.model.get_relation(GARM_CONFIGURATOR_RELATION_NAME) is not None
-
-
 def _get_ssh_debug_connections(charm: ops.CharmBase) -> list[SSHDebugInfo]:
     """Read SSH debug connection info from the debug-ssh relation.
 
@@ -336,10 +319,15 @@ class CharmState:
     Attributes:
         ssh_debug_connections: SSH debug connection info from the debug-ssh relation.
         desired_entities: GARM org/repo entities derived from the garm-configurator relation.
+        configurator_related: Whether a garm-configurator relation is present. Empty desired state
+            alone can't distinguish a removed relation from one still mid-publish; only a removed
+            relation orphans the scalesets it configured, so callers prune orphaned scalesets only
+            when this is False.
     """
 
     ssh_debug_connections: list[SSHDebugInfo]
     desired_entities: list[EntitySpec]
+    configurator_related: bool
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> "CharmState":
@@ -354,4 +342,7 @@ class CharmState:
         return cls(
             ssh_debug_connections=_get_ssh_debug_connections(charm),
             desired_entities=_get_desired_entities(charm),
+            configurator_related=(
+                charm.model.get_relation(GARM_CONFIGURATOR_RELATION_NAME) is not None
+            ),
         )

--- a/charms/garm/src/charm_state.py
+++ b/charms/garm/src/charm_state.py
@@ -173,6 +173,23 @@ def credential_name(app_id: int, installation_id: int) -> str:
     return f"app-{app_id}-{installation_id}"
 
 
+def configurator_related(charm: ops.CharmBase) -> bool:
+    """Whether a garm-configurator relation is present.
+
+    An absent relation and one that is present but not yet publishing its provider fields both
+    yield empty desired state, so callers can't tell them apart from the desired state alone.
+    Only a removed relation orphans the scalesets it configured, so only the absent case should
+    trigger their pruning.
+
+    Args:
+        charm: The charm instance.
+
+    Returns:
+        True if the garm-configurator relation exists.
+    """
+    return charm.model.get_relation(GARM_CONFIGURATOR_RELATION_NAME) is not None
+
+
 def _get_ssh_debug_connections(charm: ops.CharmBase) -> list[SSHDebugInfo]:
     """Read SSH debug connection info from the debug-ssh relation.
 

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -799,6 +799,54 @@ def test_restart_no_proxy_hash_matches_on_disk_format():
     assert captured == GarmCharm._hash_toml(expected_input)
 
 
+def test_restart_without_configurator_relation_still_prunes_orphaned_scalesets():
+    """
+    arrange: The charm is ready (postgres + secrets available) but the
+             garm-configurator relation is gone, so there are no provider configs
+             and get_relation returns None.
+    act: Run restart().
+    assert: _reconcile_runners() still runs so ScalesetReconciler can delete the
+            now-orphaned scalesets, the workload is not replanned, and the unit
+            reports that it is waiting for the garm-configurator relation.
+    """
+    charm = _make_restart_charm()
+    charm._get_configurator_provider_configs.return_value = []
+    charm.model.get_relation.return_value = None
+
+    with patch.dict(os.environ, {}, clear=True):
+        GarmCharm.restart(charm)
+
+    charm._reconcile_runners.assert_called_once()
+    charm.unit.get_container.return_value.add_layer.assert_not_called()
+    charm.update_app_and_unit_status.assert_called_once_with(
+        ops.WaitingStatus("Waiting for garm-configurator relation")
+    )
+
+
+def test_restart_configurator_relation_present_but_unpopulated_does_not_prune():
+    """
+    arrange: The charm is ready but the garm-configurator relation, though still
+             present, has not yet published its secret-dependent fields, so there
+             are no provider configs while get_relation returns the relation.
+    act: Run restart().
+    assert: _reconcile_runners() is NOT called — pruning against the empty desired
+            state would delete live scalesets — the workload is not replanned, and
+            the unit waits for the relation to finish publishing.
+    """
+    charm = _make_restart_charm()
+    charm._get_configurator_provider_configs.return_value = []
+    charm.model.get_relation.return_value = MagicMock()
+
+    with patch.dict(os.environ, {}, clear=True):
+        GarmCharm.restart(charm)
+
+    charm._reconcile_runners.assert_not_called()
+    charm.unit.get_container.return_value.add_layer.assert_not_called()
+    charm.update_app_and_unit_status.assert_called_once_with(
+        ops.WaitingStatus("Waiting for garm-configurator relation")
+    )
+
+
 def test_render_garm_toml_default_provider_applies_proxy_var_names():
     """
     arrange: No configurator providers but a non-empty proxy_var_names list.
@@ -987,11 +1035,15 @@ def test_restart_missing_configurator_relation_refreshes_stale_app_status():
         return_value={"jwt-secret": "test-jwt-secret", "db-passphrase": "a" * 32}
     )
     charm._get_configurator_provider_configs = MagicMock(return_value=[])
+    # restart() now still prunes orphaned scalesets when the relation is gone;
+    # stub it out since this test only cares about the status it reports.
+    charm._reconcile_runners = MagicMock()
 
     with (
         patch.object(GarmCharm, "config", new_callable=PropertyMock) as mock_config,
         patch.object(GarmCharm, "unit", new_callable=PropertyMock) as mock_unit,
         patch.object(GarmCharm, "app", new_callable=PropertyMock) as mock_app,
+        patch.object(GarmCharm, "model", new_callable=PropertyMock) as mock_model,
     ):
         mock_config.return_value = {}
         mock_unit.return_value = MagicMock()
@@ -999,6 +1051,7 @@ def test_restart_missing_configurator_relation_refreshes_stale_app_status():
         mock_unit.return_value.status = ops.WaitingStatus("Waiting for pebble ready")
         mock_app.return_value = MagicMock()
         mock_app.return_value.status = ops.WaitingStatus("Waiting for pebble ready")
+        mock_model.return_value.get_relation.return_value = None
 
         charm.restart()
 

--- a/charms/garm/tests/unit/test_charm.py
+++ b/charms/garm/tests/unit/test_charm.py
@@ -925,7 +925,7 @@ def test_restart_without_configurator_relation_still_prunes_orphaned_scalesets()
     """
     arrange: The charm is ready (postgres + secrets available) but the
              garm-configurator relation is gone, so there are no provider configs
-             and get_relation returns None.
+             and CharmState reports the relation absent.
     act: Run restart().
     assert: _reconcile_runners() still runs so ScalesetReconciler can delete the
             now-orphaned scalesets, the workload is not replanned, and the unit
@@ -933,9 +933,9 @@ def test_restart_without_configurator_relation_still_prunes_orphaned_scalesets()
     """
     charm = _make_restart_charm()
     charm._get_configurator_provider_configs.return_value = []
-    charm.model.get_relation.return_value = None
 
-    with patch.dict(os.environ, {}, clear=True):
+    with patch.dict(os.environ, {}, clear=True), patch("charm.CharmState") as mock_state:
+        mock_state.from_charm.return_value.configurator_related = False
         GarmCharm.restart(charm)
 
     charm._reconcile_runners.assert_called_once()
@@ -949,7 +949,7 @@ def test_restart_configurator_relation_present_but_unpopulated_does_not_prune():
     """
     arrange: The charm is ready but the garm-configurator relation, though still
              present, has not yet published its secret-dependent fields, so there
-             are no provider configs while get_relation returns the relation.
+             are no provider configs while CharmState reports the relation present.
     act: Run restart().
     assert: _reconcile_runners() is NOT called — pruning against the empty desired
             state would delete live scalesets — the workload is not replanned, and
@@ -957,9 +957,9 @@ def test_restart_configurator_relation_present_but_unpopulated_does_not_prune():
     """
     charm = _make_restart_charm()
     charm._get_configurator_provider_configs.return_value = []
-    charm.model.get_relation.return_value = MagicMock()
 
-    with patch.dict(os.environ, {}, clear=True):
+    with patch.dict(os.environ, {}, clear=True), patch("charm.CharmState") as mock_state:
+        mock_state.from_charm.return_value.configurator_related = True
         GarmCharm.restart(charm)
 
     charm._reconcile_runners.assert_not_called()
@@ -1166,6 +1166,7 @@ def test_restart_missing_configurator_relation_refreshes_stale_app_status():
         patch.object(GarmCharm, "unit", new_callable=PropertyMock) as mock_unit,
         patch.object(GarmCharm, "app", new_callable=PropertyMock) as mock_app,
         patch.object(GarmCharm, "model", new_callable=PropertyMock) as mock_model,
+        patch("charm.CharmState") as mock_state,
     ):
         mock_config.return_value = {}
         mock_unit.return_value = MagicMock()
@@ -1173,7 +1174,7 @@ def test_restart_missing_configurator_relation_refreshes_stale_app_status():
         mock_unit.return_value.status = ops.WaitingStatus("Waiting for pebble ready")
         mock_app.return_value = MagicMock()
         mock_app.return_value.status = ops.WaitingStatus("Waiting for pebble ready")
-        mock_model.return_value.get_relation.return_value = None
+        mock_state.from_charm.return_value.configurator_related = False
 
         charm.restart()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-12
+
+- `garm`: delete GARM scalesets when the `garm-configurator` relation is removed. Removing the relation left its scalesets registered in GARM (still shown by `garm-cli scaleset list`), because the charm's reconcile short-circuited on the now-missing relation before reaching the scaleset reconciler that prunes orphaned scalesets. The charm now still runs the reconcile when no configurator relation is present, so scalesets orphaned by the relation removal are disabled and deleted.
+
 ## 2026-07-09
 
 - `garm`: apply the Docker registry mirror and runner host preparation on the runner. GARM runs the injected runner-install steps as the unprivileged `runner` user, but the Docker-mirror and host-prep steps ran without `sudo`, so writing `/etc/docker/daemon.json`, restarting Docker, and adding the runner to the `lxd`/`adm` groups all failed silently — the mirror and group membership were never applied. These steps now escalate with `sudo`, matching the rest of the install script.


### PR DESCRIPTION
#### What this PR does

Deletes GARM scalesets when the `garm-configurator` relation is removed. `restart()` short-circuited on the now-empty provider configs and returned before `_reconcile_runners()` — the only path to `ScalesetReconciler`'s orphan-delete — ever ran, so scalesets whose desired spec left with the relation stayed registered in GARM (still shown by `garm-cli scaleset list`). The charm now runs the runner reconcile even when no configurator relation is present.

#### Why we need it

Removing an integration should tear down what it created. Without this, orphaned scalesets linger in GARM indefinitely after the relation is gone — consuming quota and continuing to appear in `garm-cli scaleset list` with no way for the charm to clean them up.

#### Test plan

- New unit test `test_restart_without_configurator_relation_still_prunes_orphaned_scalesets`: asserts `_reconcile_runners` runs, no Pebble replan happens (`add_layer` not called), and status stays `Waiting for garm-configurator relation`.
- Updated `test_restart_missing_configurator_relation_refreshes_stale_app_status` to stub `_reconcile_runners` (it builds the charm via `object.__new__` with no real `self.model`); its original status assertions are unchanged.
- `tox -c tox.toml -e unit` (223 passed), plus `fmt`, `lint`, `static` (pyright, 0 errors).

#### Review focus

- **Same drain-then-delete semantics, now reachable.** `ScalesetReconciler` already disables (`enabled=False`, `min_idle_runners=0`) then deletes, and catches GARM's 400 for a scaleset with active runners, retrying on the next reconcile (`update-status`). This PR doesn't change that logic — it just makes it run on the relation-removed path.
- **The fix is the one added `_reconcile_runners()` call** before the existing early return; the comment explains why the reconcile must still run with no relation present.

#### Potential breaking changes

None to config or interfaces. Behaviour change only: scalesets orphaned by removing the `garm-configurator` relation are now cleaned up instead of stranded.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — N/A, no process change
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — only a routine `changelog.md` entry, no prose docs
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration — N/A
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard — N/A
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors — N/A
- [ ] **If this PR involves Rockcraft:** I updated the version — N/A, no rockcraft change
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md` — N/A, no convention change
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** re-checked AGENTS.md 12-factor divergences — N/A
