### PR TITLE
fix(garm): treat 401 from controller-info as initialised

### DIFF
--- a/charms/garm/src/garm_api.py
+++ b/charms/garm/src/garm_api.py
@@ -84,10 +84,12 @@ class GarmApiClient:
     def is_initialized(self) -> bool:
         """Return True if GARM has already been initialised (first-run done).
 
-        GARM returns 409 Conflict on ``GET /controller-info`` until the initial
-        admin user has been created via ``POST /first-run``. Once initialised,
-        the endpoint requires auth, so this deliberately unauthenticated probe
-        gets back either 200 or 401 — both mean initialised.
+        GARM's init gate returns 409 Conflict on ``GET /controller-info`` until
+        the initial admin user has been created via ``POST /first-run``. Past
+        that gate the endpoint is auth-gated, so this deliberately unauthenticated
+        probe sees 401 once GARM is initialised. Both 401 and 200 therefore mean
+        the init gate has been passed (initialised); only 409 means first-run is
+        still pending.
 
         Returns:
             True if GARM is initialised, False if it is waiting for first-run.

--- a/charms/garm/src/garm_api.py
+++ b/charms/garm/src/garm_api.py
@@ -82,14 +82,9 @@ class GarmApiClient:
         return ApiClient(configuration=Configuration(host=self._base_url))
 
     def is_initialized(self) -> bool:
-        """Return True if GARM has already been initialised (first-run done).
+        """Return whether GARM has completed first-run initialisation.
 
-        GARM's init gate returns 409 Conflict on ``GET /controller-info`` until
-        the initial admin user has been created via ``POST /first-run``. Past
-        that gate the endpoint is auth-gated, so this deliberately unauthenticated
-        probe sees 401 once GARM is initialised. Both 401 and 200 therefore mean
-        the init gate has been passed (initialised); only 409 means first-run is
-        still pending.
+        Probes ``GET /controller-info``, GARM's only auth-free first-run signal.
 
         Returns:
             True if GARM is initialised, False if it is waiting for first-run.
@@ -103,6 +98,8 @@ class GarmApiClient:
                 api.controller_info(_request_timeout=_REQUEST_TIMEOUT)
                 return True
             except ApiException as exc:
+                # 409 is GARM's init gate rejecting the probe until first-run
+                # creates the admin user; getting past it means initialised.
                 if exc.status == 409:
                     return False
                 if exc.status == 401:

--- a/charms/garm/src/garm_api.py
+++ b/charms/garm/src/garm_api.py
@@ -85,7 +85,9 @@ class GarmApiClient:
         """Return True if GARM has already been initialised (first-run done).
 
         GARM returns 409 Conflict on ``GET /controller-info`` until the initial
-        admin user has been created via ``POST /first-run``.
+        admin user has been created via ``POST /first-run``. Once initialised,
+        the endpoint requires auth, so this deliberately unauthenticated probe
+        gets back either 200 or 401 — both mean initialised.
 
         Returns:
             True if GARM is initialised, False if it is waiting for first-run.
@@ -101,6 +103,11 @@ class GarmApiClient:
             except ApiException as exc:
                 if exc.status == 409:
                     return False
+                if exc.status == 401:
+                    # Auth is only enforced once first-run has created the admin
+                    # user, so a 401 on this deliberately unauthenticated probe
+                    # means the init gate already let the request through.
+                    return True
                 raise GarmApiError(
                     f"Unexpected response from GARM controller-info ({exc.status}): {exc.body}"
                 ) from exc

--- a/charms/garm/tests/unit/test_garm_api.py
+++ b/charms/garm/tests/unit/test_garm_api.py
@@ -33,14 +33,16 @@ def _stub_api_client(client):
     [
         (None, True),
         (ApiException(status=409), False),
+        (ApiException(status=401), True),
     ],
-    ids=["200-ok", "409-not-initialised"],
+    ids=["200-ok", "409-not-initialised", "401-initialised-unauthenticated-probe"],
 )
 def test_is_initialized(side_effect, expected):
     """
     arrange: GarmApiClient pointed at BASE_URL with a stubbed api_client.
-    act: Call is_initialized(); ControllerInfoApi raises ApiException(409) or succeeds.
-    assert: Returns True on success, False on 409.
+    act: Call is_initialized(); ControllerInfoApi raises ApiException(409/401) or succeeds.
+    assert: Returns True on success or 401 (auth enforced means already initialised),
+        False on 409.
     """
     client = GarmApiClient(BASE_URL)
     with _stub_api_client(client):

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-07-13
 
-- `garm`: stop the config-changed hook from erroring on an already-initialised GARM. The charm's first-run check probed GARM's `controller-info` endpoint without a token and treated the resulting `401` (returned once GARM is initialised and requires auth) as a fatal error, failing the hook on any config or charm change that rewrote the workload config — e.g. a charm upgrade. The probe now treats `401` the same as `200`: both mean GARM is past its init gate and already initialised.
+- `garm`: stop the config-changed hook from erroring on an already-initialised GARM. The charm's first-run check probed GARM's `controller-info` endpoint without a token and treated the resulting `401` (returned once GARM is initialised and requires auth) as a fatal error, failing the hook on any config or charm change that rewrote the workload config — for example, a charm upgrade. The probe now treats `401` the same as `200`: both mean GARM is past its init gate and already initialised.
 - `garm`: reliably apply proxy changes to the GARM workload. The charm gated the workload's Pebble layer rewrite on a hash of the on-disk config file, which excluded the proxy environment *values* — so changing or clearing a proxy value while the variable set stayed the same never rewrote the layer, leaving the old value in the plan. The on-disk file could also drift from the layer and wedge it permanently. The charm now compares the freshly rendered hash (which includes the proxy values) against the `config_hash` stored in the container's current Pebble plan, so proxy value changes and clears reliably replan the workload.
 
 ## 2026-07-12

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-07-13
 
+- `garm`: stop the config-changed hook from erroring on an already-initialised GARM. The charm's first-run check probed GARM's `controller-info` endpoint without a token and treated the resulting `401` (returned once GARM is initialised and requires auth) as a fatal error, failing the hook on any config or charm change that rewrote the workload config — e.g. a charm upgrade. The probe now treats `401` the same as `200`: both mean GARM is past its init gate and already initialised.
 - `garm`: reliably apply proxy changes to the GARM workload. The charm gated the workload's Pebble layer rewrite on a hash of the on-disk config file, which excluded the proxy environment *values* — so changing or clearing a proxy value while the variable set stayed the same never rewrote the layer, leaving the old value in the plan. The on-disk file could also drift from the layer and wedge it permanently. The charm now compares the freshly rendered hash (which includes the proxy values) against the `config_hash` stored in the container's current Pebble plan, so proxy value changes and clears reliably replan the workload.
 
 ## 2026-07-12

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-07-13
 
-- `garm`: stop the config-changed hook from erroring on an already-initialised GARM. The charm's first-run check probed GARM's `controller-info` endpoint without a token and treated the resulting `401` (returned once GARM is initialised and requires auth) as a fatal error, failing the hook on any config or charm change that rewrote the workload config — for example, a charm upgrade. The probe now treats `401` the same as `200`: both mean GARM is past its init gate and already initialised.
+- `garm`: prevent the config-changed hook from failing on an already-initialized GARM. The charm's first-run check probed GARM's `controller-info` endpoint without a token and treated the resulting `401` (returned once GARM is initialized and requires auth) as a fatal error that aborted the hook on any config or charm change that rewrote the workload config — for example, a charm upgrade. The probe now treats `401` the same as `200`: both mean GARM is past its init gate and already initialized.
 - `garm`: reliably apply proxy changes to the GARM workload. The charm gated the workload's Pebble layer rewrite on a hash of the on-disk config file, which excluded the proxy environment *values* — so changing or clearing a proxy value while the variable set stayed the same never rewrote the layer, leaving the old value in the plan. The on-disk file could also drift from the layer and wedge it permanently. The charm now compares the freshly rendered hash (which includes the proxy values) against the `config_hash` stored in the container's current Pebble plan, so proxy value changes and clears reliably replan the workload.
 
 ## 2026-07-12


### PR DESCRIPTION
#### What this PR does

Fixes `GarmApiClient.is_initialized()` so it treats a `401` from GARM's `controller-info` endpoint as "initialised" (same as `200`), instead of raising and failing the charm hook.

#### Why we need it

The first-run check probes `GET /api/v1/controller-info` with a deliberately unauthenticated client. GARM puts that endpoint behind two middlewares: an init-required gate (returns `409` until first-run creates the admin user) and JWT auth (returns `401` when there's no token). The code only understood `200` → initialised and `409` → not-initialised, and raised on anything else.

On an already-initialised GARM (e.g. after a charm upgrade with persisted PostgreSQL), the init gate passes and the tokenless probe hits the auth gate → `401`, which was wrongly treated as fatal and failed the `config-changed` hook. It only appeared to "self-heal" because Juju's retry found the workload config hash already applied and short-circuited `restart()` before re-reaching the probe. The bug is latent for any config/charm change that rewrites the workload config on an initialised controller.

A `401` unambiguously means the request got past the init gate, so it means initialised — the probe never needs a token to answer that question.

#### Test plan

- Extended the existing `test_is_initialized` parametrize table in `charms/garm/tests/unit/test_garm_api.py` with a `401 → True` case.
- `tox -c tox.toml -e unit` → 229 passed; `-e lint` and `-e static` (pyright: 0 errors) clean.

#### Review focus

- The semantic claim that `401` on the unauthenticated `controller-info` probe reliably means "initialised" (init gate passed, auth gate rejected). `wait_for_ready()` is intentionally unchanged — `200`/`401`/`409` all confirm the HTTP server is up, and it still retries only on connection-level errors.

#### Potential breaking changes / new dependencies

None. No new dependencies, APIs, or workflow changes.

#### Checklist

- [x] Changes comply with the project's coding standards and guidelines (see CONTRIBUTING.md and STYLE.md)
- [ ] `CONTRIBUTING.md` has been updated upon changes to the contribution/development process (e.g. changes to the way tests are run) — n/a, no process change
- [ ] Technical author has been assigned to review the PR in case of documentation changes (usually *.md files) — n/a, changelog only
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration — n/a
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard — n/a
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors — n/a
- [ ] **If this PR involves Rockcraft:** I updated the version — n/a
- [ ] **If this PR adds/removes a charm, or changes a charm's base class, conventions, tooling, or repo structure:** I updated the relevant `AGENTS.md` — n/a
- [ ] **If this PR changes `.copilot-collections.yaml` or `.github/instructions/`:** I re-checked whether the `AGENTS.md` "12-factor divergences" guidance still matches upstream — n/a
